### PR TITLE
Add Bannerlord.Harmony module dependency

### DIFF
--- a/MapPerfFix/MapPerfFix.csproj
+++ b/MapPerfFix/MapPerfFix.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Reference Include="0Harmony, Version=2.4.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Lib.Harmony.2.4.1\lib\net472\0Harmony.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/MapPerfFix/SubModule.xml
+++ b/MapPerfFix/SubModule.xml
@@ -1,24 +1,24 @@
 <Module>
-  <Name value="MapPerfProbe"/>
-  <Id value="MapPerfProbe"/>
-  <Version value="1.0.0"/>
-  <SingleplayerModule value="true"/>
-  <Official value="false"/>
+  <Name value="MapPerfProbe" />
+  <Id value="MapPerfProbe" />
+  <Version value="1.0.0" />
+  <SingleplayerModule value="true" />
+  <Official value="false" />
   <DependedModules>
-    <DependedModule Id="Native"/>
-    <DependedModule Id="SandBoxCore"/>
-    <DependedModule Id="Sandbox"/>
-    <DependedModule Id="StoryMode"/>
-	<DependedModule Id="Bannerlord.Harmony"/>
+    <DependedModule Id="Native" />
+    <DependedModule Id="SandBoxCore" />
+    <DependedModule Id="Sandbox" />
+    <DependedModule Id="StoryMode" />
+    <DependedModule Id="Bannerlord.Harmony" />
   </DependedModules>
   <SubModules>
     <SubModule>
-      <Name value="MapPerfProbe SubModule"/>
-      <DLLName value="MapPerfProbe.dll"/>
-      <SubModuleClassType value="MapPerfProbe.SubModule"/>
+      <Name value="MapPerfProbe SubModule" />
+      <DLLName value="MapPerfProbe.dll" />
+      <SubModuleClassType value="MapPerfProbe.SubModule" />
       <Tags>
-        <Tag key="DedicatedServerType" value="none"/>
-        <Tag key="IsNoRenderModeElement" value="false"/>
+        <Tag key="DedicatedServerType" value="none" />
+        <Tag key="IsNoRenderModeElement" value="false" />
       </Tags>
     </SubModule>
   </SubModules>

--- a/MapPerfFix/Submodule.xml
+++ b/MapPerfFix/Submodule.xml
@@ -1,23 +1,24 @@
 <Module>
-  <Name value="MapPerfProbe"/>
-  <Id value="MapPerfProbe"/>
-  <Version value="1.0.0"/>
-  <SingleplayerModule value="true"/>
-  <Official value="false"/>
+  <Name value="MapPerfProbe" />
+  <Id value="MapPerfProbe" />
+  <Version value="1.0.0" />
+  <SingleplayerModule value="true" />
+  <Official value="false" />
   <DependedModules>
-    <DependedModule Id="Native"/>
-    <DependedModule Id="SandBoxCore"/>
-    <DependedModule Id="Sandbox"/>
-    <DependedModule Id="StoryMode"/>
+    <DependedModule Id="Native" />
+    <DependedModule Id="SandBoxCore" />
+    <DependedModule Id="Sandbox" />
+    <DependedModule Id="StoryMode" />
+    <DependedModule Id="Bannerlord.Harmony" />
   </DependedModules>
   <SubModules>
     <SubModule>
-      <Name value="MapPerfProbe SubModule"/>
-      <DLLName value="MapPerfProbe.dll"/>
-      <SubModuleClassType value="MapPerfProbe.SubModule"/>
+      <Name value="MapPerfProbe SubModule" />
+      <DLLName value="MapPerfProbe.dll" />
+      <SubModuleClassType value="MapPerfProbe.SubModule" />
       <Tags>
-        <Tag key="DedicatedServerType" value="none"/>
-        <Tag key="IsNoRenderModeElement" value="false"/>
+        <Tag key="DedicatedServerType" value="none" />
+        <Tag key="IsNoRenderModeElement" value="false" />
       </Tags>
     </SubModule>
   </SubModules>


### PR DESCRIPTION
## Summary
- add Bannerlord.Harmony to the module dependency list so Harmony loads before the probe
- mirror the dependency entry in both module descriptor files for consistency

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68da14888f4483209cbbbbf4da4708bc