### PR TITLE
Fix Harmony unpatch invocation

### DIFF
--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -52,7 +52,8 @@ namespace MapPerfProbe
 
         protected override void OnSubModuleUnloaded()
         {
-            Harmony.UnpatchAll(HId);
+            var harmony = new Harmony(HId);
+            harmony.UnpatchAll(HId);
             FlushSummary(force: true);
             Log("=== MapPerfProbe stop ===");
         }


### PR DESCRIPTION
## Summary
- create a Harmony instance before calling UnpatchAll when unloading the submodule
- ensure the module unload cleans up patches using the instance method

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68da1a560e2c8320b53befad527291a1