### PR TITLE
Decouple Harmony reference and add runtime binding

### DIFF
--- a/MapPerfFix/MapPerfFix.csproj
+++ b/MapPerfFix/MapPerfFix.csproj
@@ -50,10 +50,6 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.4.1\lib\net472\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -1,4 +1,3 @@
-using HarmonyLib;
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -23,51 +22,43 @@ namespace MapPerfProbe
 
         protected override void OnSubModuleLoad()
         {
-            var harmony = new Harmony(HId);
             var root = AppDomain.CurrentDomain.BaseDirectory;
             var logDir = Path.Combine(root, "Modules", "MapPerfProbe", "Log");
-            try { Directory.CreateDirectory(logDir); }
-            catch { /* ignore path issues */ }
+            try { Directory.CreateDirectory(logDir); } catch { }
             _logFile = Path.Combine(logDir, "probe.log");
             Log("=== MapPerfProbe start ===");
 
-            // Patch buckets: MapState ticks, CampaignEventDispatcher ticks, Gauntlet MapScreen ticks.
-            TryPatchType(harmony, "TaleWorlds.CampaignSystem.GameState.MapState", new[] {"OnTick","OnMapModeTick","OnFrameTick"});
+            var harmony = CreateHarmony();
+            if (harmony == null)
+            {
+                Log("Harmony not found. Only frame/GC logging active.");
+                return;
+            }
 
-            TryPatchType(harmony, "TaleWorlds.CampaignSystem.MapState",          new[] {"OnTick","OnMapModeTick","OnFrameTick"});
-
-            TryPatchType(harmony, "TaleWorlds.CampaignSystem.CampaignEventDispatcher",
-                new[] { "OnTick", "OnHourlyTick", "OnDailyTick" });
-
-            TryPatchType(harmony, "SandBox.View.Map.MapScreen",
-                new[] { "OnFrameTick", "Tick", "OnTick" });
-
-            // Optional: UI context update (if present)
-            TryPatchType(harmony, "TaleWorlds.GauntletUI.UIContext",
-                new[] { "Update", "Tick" });
-
-            TryPatchType(harmony, "TaleWorlds.GauntletUI.GauntletLayer",
-                new[] { "OnLateUpdate", "Tick" });
+            TryPatchType(harmony, "TaleWorlds.CampaignSystem.GameState.MapState", new[] { "OnTick", "OnMapModeTick", "OnFrameTick" });
+            TryPatchType(harmony, "TaleWorlds.CampaignSystem.MapState",          new[] { "OnTick", "OnMapModeTick", "OnFrameTick" });
+            TryPatchType(harmony, "TaleWorlds.CampaignSystem.CampaignEventDispatcher", new[] { "OnTick", "OnHourlyTick", "OnDailyTick" });
+            TryPatchType(harmony, "SandBox.View.Map.MapScreen", new[] { "OnFrameTick", "Tick", "OnTick" });
+            TryPatchType(harmony, "TaleWorlds.GauntletUI.UIContext", new[] { "Update", "Tick" });
+            TryPatchType(harmony, "TaleWorlds.GauntletUI.GauntletLayer", new[] { "OnLateUpdate", "Tick" });
         }
 
         protected override void OnSubModuleUnloaded()
         {
-            var harmony = new Harmony(HId);
-            harmony.UnpatchAll(HId);
+            var harmony = CreateHarmony();
+            if (harmony != null) harmony.GetType().GetMethod("UnpatchAll", new[] { typeof(string) })?.Invoke(harmony, new object[] { HId });
             FlushSummary(force: true);
             Log("=== MapPerfProbe stop ===");
         }
 
         protected override void OnApplicationTick(float dt)
         {
-            // Frame time sampling
             var now = Stopwatch.GetTimestamp();
             double ms = (now - _lastFrameTS) * 1000.0 / Stopwatch.Frequency;
             _lastFrameTS = now;
             if (ms > 25.0 && IsOnMap())
                 Log($"FRAME spike {ms:F1} ms [{(IsPaused() ? "PAUSED" : "RUN")}]");
 
-            // GC sampling
             for (int g = 0; g < 3; g++)
             {
                 int c = GC.CollectionCount(g);
@@ -78,41 +69,46 @@ namespace MapPerfProbe
                 }
             }
 
-            // Periodic aggregate flush
             _nextFlush -= dt;
             if (_nextFlush <= 0.0)
             {
-                _nextFlush = 2.0; // every ~2 real seconds
+                _nextFlush = 2.0;
                 if (IsOnMap()) FlushSummary(force: false);
             }
         }
 
-        private static bool IsOnMap()
+        private static object CreateHarmony()
         {
-            var s = GameStateManager.Current?.ActiveState;
-            var n = s?.GetType().FullName ?? "";
-            return n.EndsWith(".MapState") || n == "MapState";
+            // Bind to Harmony only if Bannerlord.Harmony loaded 0Harmony into AppDomain
+            var ht = Type.GetType("HarmonyLib.Harmony, 0Harmony", throwOnError: false);
+            if (ht == null) return null;
+            return Activator.CreateInstance(ht, new object[] { HId });
         }
 
-        private static void TryPatchType(Harmony harmony, string typeName, string[] methodNames)
+        private static void TryPatchType(object harmony, string typeName, string[] methodNames)
         {
-            var t = AccessTools.TypeByName(typeName);
+            var t = FindType(typeName);
             if (t == null) return;
+
+            var ht = harmony.GetType();
+            var hmType = Type.GetType("HarmonyLib.HarmonyMethod, 0Harmony", throwOnError: false);
+            var hmCtor = hmType?.GetConstructor(new[] { typeof(MethodInfo) });
+            var patchMi = ht.GetMethod("Patch", new[] { typeof(MethodBase), hmType, hmType, hmType, hmType });
+
+            var pre = typeof(SubModule).GetMethod(nameof(PerfPrefix), BindingFlags.Static | BindingFlags.Public);
+            var post = typeof(SubModule).GetMethod(nameof(PerfPostfix), BindingFlags.Static | BindingFlags.Public);
+            var preHM = hmCtor?.Invoke(new object[] { pre });
+            var postHM = hmCtor?.Invoke(new object[] { post });
 
             foreach (var m in t.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             {
                 if (!methodNames.Contains(m.Name)) continue;
                 if (m.ReturnType != typeof(void)) continue;
-
-                // Accept 0-2 args; first may be float dt
-                var pars = m.GetParameters();
-                if (pars.Length > 2) continue;
+                if (m.GetParameters().Length > 2) continue;
 
                 try
                 {
-                    harmony.Patch(m,
-                        prefix: new HarmonyMethod(typeof(SubModule), nameof(PerfPrefix)),
-                        postfix: new HarmonyMethod(typeof(SubModule), nameof(PerfPostfix)));
+                    patchMi?.Invoke(harmony, new object[] { m, preHM, postHM, null, null });
                     Log($"Patched {t.FullName}.{m.Name}");
                 }
                 catch (Exception ex)
@@ -122,11 +118,18 @@ namespace MapPerfProbe
             }
         }
 
-        // Shared prefix/postfix with __state
-        public static void PerfPrefix(MethodBase __originalMethod, out long __state)
+        private static Type FindType(string fullName)
         {
-            __state = Stopwatch.GetTimestamp();
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var tt = asm.GetType(fullName, false);
+                if (tt != null) return tt;
+            }
+            return Type.GetType(fullName, false);
         }
+
+        public static void PerfPrefix(MethodBase __originalMethod, out long __state)
+            => __state = Stopwatch.GetTimestamp();
 
         public static void PerfPostfix(MethodBase __originalMethod, long __state)
         {
@@ -137,92 +140,49 @@ namespace MapPerfProbe
 
         private static void FlushSummary(bool force)
         {
-            // Top offenders last window
-            var top = Stats.Values
-                .Select(s => s.SnapshotAndReset())
-                .Where(s => s.Count > 0)
-                .OrderByDescending(s => s.P95)
-                .Take(8)
-                .ToList();
-
+            var top = Stats.Values.Select(s => s.SnapshotAndReset()).Where(s => s.Count > 0)
+                                  .OrderByDescending(s => s.P95).Take(8).ToList();
             if (top.Count == 0 && !force) return;
-
             Log($"-- bucket summary [{(IsPaused() ? "PAUSED" : "RUN")}] --");
             foreach (var s in top)
                 Log($"{s.Name,-48} avg {s.Avg:F1} ms | p95 {s.P95:F1} | max {s.Max:F1} | n {s.Count}");
         }
 
+        private static bool IsOnMap()
+        {
+            var s = GameStateManager.Current?.ActiveState;
+            var n = s?.GetType().FullName ?? "";
+            return n.EndsWith(".MapState") || n == "MapState";
+        }
+
         private static bool IsPaused()
         {
             var camp = Campaign.Current;
-            if (camp == null) return false;
-            return camp.TimeControlMode == CampaignTimeControlMode.Stop;
+            return camp != null && camp.TimeControlMode == CampaignTimeControlMode.Stop;
         }
 
         private static void Log(string line)
         {
             if (string.IsNullOrEmpty(_logFile)) return;
-            try
-            {
-                File.AppendAllText(_logFile, $"[{DateTime.Now:HH:mm:ss}] {line}\n");
-            }
-            catch { /* ignore file IO errors */ }
+            try { File.AppendAllText(_logFile, $"[{DateTime.Now:HH:mm:ss}] {line}\n"); } catch { }
         }
 
         private sealed class PerfStat
         {
-            private double _sum, _max;
-            private int _n;
-            private readonly double[] _ring = new double[128];
-            private int _i;
+            private double _sum, _max; private int _n;
+            private readonly double[] _ring = new double[128]; private int _i;
             public string Name { get; }
-
-            public PerfStat(MethodBase m)
-            {
-                Name = $"{m.DeclaringType.FullName}.{m.Name}";
-            }
-
-            public void Add(double ms)
-            {
-                _sum += ms;
-                if (ms > _max) _max = ms;
-                _ring[_i++ & 127] = ms;
-                _n++;
-            }
-
+            public PerfStat(MethodBase m) => Name = $"{m.DeclaringType.FullName}.{m.Name}";
+            public void Add(double ms) { _sum += ms; if (ms > _max) _max = ms; _ring[_i++ & 127] = ms; _n++; }
             public Snapshot SnapshotAndReset()
             {
-                var cnt = Math.Min(_n, _ring.Length);
-                var arr = new double[cnt];
-                // copy last cnt samples
+                int cnt = Math.Min(_n, _ring.Length); var arr = new double[cnt];
                 for (int k = 0; k < cnt; k++) arr[k] = _ring[(_i - 1 - k) & 127];
-                Array.Sort(arr);
-                double p95 = 0.0;
-                if (cnt > 0)
-                {
-                    int idx = (int)Math.Floor(cnt * 0.95) - 1;
-                    if (idx < 0) idx = 0;
-                    if (idx >= cnt) idx = cnt - 1;
-                    p95 = arr[idx];
-                }
-                var snap = new Snapshot
-                {
-                    Name = Name,
-                    Avg = _n > 0 ? _sum / _n : 0.0,
-                    Max = _max,
-                    P95 = p95,
-                    Count = _n
-                };
-                _sum = 0; _max = 0; _n = 0; // keep ring for continuity
-                return snap;
+                Array.Sort(arr); int idx = cnt == 0 ? 0 : Math.Max(0, Math.Min(cnt - 1, (int)Math.Floor(cnt * 0.95) - 1));
+                var s = new Snapshot { Name = Name, Avg = _n > 0 ? _sum / _n : 0.0, Max = _max, P95 = cnt > 0 ? arr[idx] : 0.0, Count = _n };
+                _sum = 0; _max = 0; _n = 0; return s;
             }
         }
-
-        private struct Snapshot
-        {
-            public string Name;
-            public double Avg, Max, P95;
-            public int Count;
-        }
+        private struct Snapshot { public string Name; public double Avg, Max, P95; public int Count; }
     }
 }


### PR DESCRIPTION
## Summary
- remove the compile-time dependency on 0Harmony from the mod project
- update SubModule to locate Harmony via reflection and apply patches only when it is already loaded
- preserve existing perf logging while ensuring the module still unloads patches and writes summaries

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68da219c5c7c83209cdea8d3de752a70