### PR TITLE
Fix map throttle prefix shadowing

### DIFF
--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -654,6 +654,7 @@ namespace MapPerfProbe
                 _mapScreenFastTimeValid = false;
                 _mapScreenThrottleActive = false;
                 _mapHotGate = false;
+
                 if (__instance == null || paused)
                 {
                     _skipMapOnFrameTick = false;
@@ -664,6 +665,7 @@ namespace MapPerfProbe
                 _mapHotGate = ShouldEnableMapHot(fastTime);
                 _mapScreenFastTime = fastTime;
                 _mapScreenFastTimeValid = true;
+
                 if (!fastTime)
                 {
                     _skipMapOnFrameTick = false;
@@ -684,12 +686,12 @@ namespace MapPerfProbe
                 return true;
             }
 
-            if (!MapScreenFrameHooks.Contains(methodName))
-                return true;
+            if (!MapScreenFrameHooks.Contains(methodName)) return true;
 
             var hadFastTime = _mapScreenFastTimeValid;
             var cachedFastTime = _mapScreenFastTime;
             _mapScreenFastTimeValid = false;
+
             if (__instance == null || IsPaused())
             {
                 _mapScreenThrottleActive = false;
@@ -698,8 +700,8 @@ namespace MapPerfProbe
                 return true;
             }
 
-            var fastTime = hadFastTime ? cachedFastTime : IsFastTime();
-            if (!fastTime)
+            bool fastTime2 = hadFastTime ? cachedFastTime : IsFastTime();
+            if (!fastTime2)
             {
                 _mapScreenThrottleActive = false;
                 _skipMapOnFrameTick = false;


### PR DESCRIPTION
## Summary
- update MapScreenOnFrameTickPrefix to avoid fastTime variable shadowing and keep cached fast-time reuse

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68db944537e0832082b4147f70dbba9a