### PR TITLE
fix: reset slicer counters via helper

### DIFF
--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -159,6 +159,13 @@ namespace MapPerfProbe
         internal static double TicksToMs => TicksToMsConst;
         private const double BytesPerKiB = 1024.0;
 
+        internal static void ResetChildBackpressureCounters()
+        {
+            Interlocked.Exchange(ref _childBacklogToken, 0);
+            Interlocked.Exchange(ref _childBackpressureSkips, 0);
+            _childBackpressureSkipsByMethod.Clear();
+        }
+
         private struct AllocWarnBudget
         {
             public double NextReset;
@@ -3097,8 +3104,7 @@ namespace MapPerfProbe
                 if (_qHandlers.Count != 0)
                     return;
                 _queueBackpressureLatched = false;
-                Interlocked.Exchange(ref _childBacklogToken, 0);
-                Interlocked.Exchange(ref _childBackpressureSkips, 0);
+                SubModule.ResetChildBackpressureCounters();
             }
 
             _handlerCache.Clear();
@@ -3107,7 +3113,6 @@ namespace MapPerfProbe
             _hubNoHandlersUntilInst.Clear();
             _hubHasHandlers.Clear();
             _hubNoHandlersUntil.Clear();
-            _childBackpressureSkipsByMethod.Clear();
         }
 
         public static void Pump(double msBudget)


### PR DESCRIPTION
## Summary
- add a SubModule helper to clear child backpressure counters safely
- reuse the helper from PeriodicSlicer.ClearCachesIfIdle instead of direct field access

## Testing
- not run (per instructions)

## Rationale
Fix CS0103 compile errors caused by PeriodicSlicer referencing private SubModule fields directly.

## Risk
Low; the helper wraps existing counter resets without changing behavior.

------
https://chatgpt.com/codex/tasks/task_e_68dcca8df6708320a92c9aa8511a748a