### PR TITLE
fix(patch): call logger without ternary

### DIFF
--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -3321,8 +3321,11 @@ namespace MapPerfProbe
                     bin--;
                 Interlocked.Increment(ref OvershootBins[bin]);
                 var lvlWarn = SubModule.PausedSnapshot ? overshootMs > 4.0 : overshootMs > 2.0;
-                (lvlWarn ? MapPerfLog.Warn : MapPerfLog.Info)(
-                    $"[slice] pump overshoot {overshootMs:F2} ms (pumped {pumped}, rem {remaining}, paused {SubModule.PausedSnapshot})");
+                var msg = $"[slice] pump overshoot {overshootMs:F2} ms (pumped {pumped}, rem {remaining}, paused {SubModule.PausedSnapshot})";
+                if (lvlWarn)
+                    MapPerfLog.Warn(msg);
+                else
+                    MapPerfLog.Info(msg);
             }
             if (string.IsNullOrEmpty(exitReason))
                 exitReason = "done";


### PR DESCRIPTION
## Summary
- replace the ternary logger invocation with an explicit branch in SubModule.Pump to satisfy C# syntax rules

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dd046235508320a700bef6d89ce6e5