### PR TITLE
chore: use compile-time MCM dependency

### DIFF
--- a/MapPerfFix/MapPerfFix.csproj
+++ b/MapPerfFix/MapPerfFix.csproj
@@ -89,10 +89,10 @@
     <Reference Include="TaleWorlds.TwoDimension">
       <HintPath>D:\Spiele\Mount and Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.TwoDimension.dll</HintPath>
     </Reference>
-    <Reference Include="MCM.Abstractions">
-      <HintPath>D:\Spiele\Mount and Blade II Bannerlord\Modules\MCMv5\bin\Win64_Shipping_Client\MCM.Abstractions.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Compile-time only; do not copy MCM into your mod output -->
+    <PackageReference Include="Bannerlord.MCM" Version="5.10.1" IncludeAssets="compile" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MapPerfConfig.cs" />

--- a/MapPerfFix/SubModule.xml
+++ b/MapPerfFix/SubModule.xml
@@ -6,7 +6,7 @@
   <Singleplayer value="true" />
   <Multiplayer value="false" />
   <DependedModules>
-    <DependedModule Id="MCMv5" DependentVersion="v5" Optional="false" />
+    <DependedModule Id="MCMv5" DependentVersion="v5" Optional="true" />
   </DependedModules>
   <SubModules>
     <SubModule>


### PR DESCRIPTION
## Summary
- replace the direct MCM.Abstractions DLL reference with the Bannerlord.MCM NuGet package limited to compile assets
- mark the MCM module dependency as optional so the mod can load without the UI plugin installed

## Testing
- not run (per instructions)

Rationale: rely on NuGet for compile-only MCM access so the mod no longer ships third-party binaries.
Risk: low; dependency usage is unchanged at runtime and the module can still load without MCM present.

------
https://chatgpt.com/codex/tasks/task_e_68ddf45b1ab48320899ebe3c9d23f5d4