### PR TITLE
fix: update MCM package reference for dropdown support

### DIFF
--- a/MapPerfFix/MapPerfFix.csproj
+++ b/MapPerfFix/MapPerfFix.csproj
@@ -16,6 +16,9 @@
     <PlatformTarget>x64</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
@@ -93,8 +96,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <!-- Compile-time only: lets MCM attributes/types resolve without bundling MCM -->
-    <PackageReference Include="Bannerlord.MCM" Version="5.10.1" IncludeAssets="compile" />
+    <!-- Compile-time only: lets MCM v5 attributes & Dropdown<T> resolve without bundling MCM -->
+    <!-- Dropdown<T> lives in MCM 5.12+ -->
+    <PackageReference Include="Bannerlord.MCM" Version="5.12.1" IncludeAssets="compile" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MapPerfConfig.cs" />


### PR DESCRIPTION
## Summary
- ensure the project restores packages via PackageReference so compile-time-only dependencies resolve
- bump Bannerlord.MCM to 5.12.1 to expose Dropdown<T> for the settings UI

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68ddfa64ae3c83208cfb77df8f5c30cd