### PR TITLE
fix: remove stale MCMv5 DLL reference

### DIFF
--- a/MapPerfFix/MapPerfFix.csproj
+++ b/MapPerfFix/MapPerfFix.csproj
@@ -16,9 +16,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-  </PropertyGroup>
+  <PropertyGroup><RestoreProjectStyle>PackageReference</RestoreProjectStyle></PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
@@ -42,9 +40,6 @@
   <ItemGroup>
     <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Bannerlord.Lib.Harmony.2.2.2\lib\net472\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="MCMv5, Version=5.10.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Bannerlord.MCM.5.10.1\lib\netstandard2.0\MCMv5.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="TaleWorlds.ActivitySystem">

--- a/MapPerfFix/MapPerfSettings.cs
+++ b/MapPerfFix/MapPerfSettings.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using MCM.Abstractions.Attributes;
 using MCM.Abstractions.Attributes.v2;
 using MCM.Abstractions.Base.Global;
@@ -33,7 +32,7 @@ namespace MapPerfProbe
         [SettingPropertyDropdown("Preset", Order = 2)]
         public Dropdown<ThrottlePreset> PresetOption { get; set; } =
             new Dropdown<ThrottlePreset>(
-                Enum.GetValues(typeof(ThrottlePreset)).Cast<ThrottlePreset>().ToArray(),
+                (ThrottlePreset[])Enum.GetValues(typeof(ThrottlePreset)),
                 (int)ThrottlePreset.Balanced
             );
 


### PR DESCRIPTION
## Summary
- drop the direct reference to the outdated MCMv5.dll so the NuGet package provides Dropdown<T>
- initialize the preset dropdown using the MCM 5.12 API

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68ddfb8921608320b2fa8c40664e3324