### PR TITLE
fix(config): avoid open generic null pattern

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -17,7 +17,7 @@ namespace MapPerfProbe
                         if (allowEmptyString || !string.IsNullOrEmpty(str))
                             return value;
                     }
-                    else if (!(value is null))
+                    else if (!object.ReferenceEquals(value, null))
                     {
                         return value;
                     }

--- a/MapPerfFix/MsgFilter.cs
+++ b/MapPerfFix/MsgFilter.cs
@@ -1,3 +1,5 @@
+// Volatile.Read/Write refs are intentional; silence CS0420 for this file.
+#pragma warning disable CS0420
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -370,4 +372,5 @@ namespace MapPerfProbe
         }
     }
 }
+#pragma warning restore CS0420
 


### PR DESCRIPTION
## Summary
- swap the `value is null` pattern match for an `object.ReferenceEquals` check so open generics build on the configured language version
- locally suppress CS0420 warnings in `MsgFilter` because the volatile field access pattern is intentional

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68de003dbf3083208aa1abe9b4b635ab