### PR TITLE
Expose slicer pump tail tuning

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -36,7 +36,7 @@ namespace MapPerfProbe
         internal static bool EnableMapThrottle => Get(s => s.EnableMapThrottle, true);
         internal static bool ThrottleOnlyInFastTime => Get(s => s.ThrottleOnlyInFastTime, true);
         internal static bool DesyncSimWhileThrottling => Get(s => s.DesyncSimWhileThrottling, true);
-        internal static int SimTickEveryNSkipped => Get(s => s.SimTickEveryNSkipped, 2);
+        internal static int SimTickEveryNSkipped => Get(s => s.SimTickEveryNSkipped, 8);
         internal static int MaxDesyncMs => Get(s => s.MaxDesyncMs, 1000);
         internal static int DesyncLowWatermarkMs => Get(s => s.DesyncLowWatermarkMs, 400);
         internal static ThrottlePreset Preset => Get(s => s.Preset, ThrottlePreset.Balanced);
@@ -58,8 +58,14 @@ namespace MapPerfProbe
         internal static double PumpBudgetRunMs => 3.0;
         internal static double PumpBudgetFastMs => 8.0;
         internal static double PumpBudgetRunBoostMs => 4.0;
-        internal static double PumpBudgetFastBoostMs => 12.0;
-        internal static int PumpBacklogBoostThreshold => 10_000;
+        internal static double PumpBudgetFastBoostMs => 24.0;
+        internal static int PumpBacklogBoostThreshold => 1_000;
+        internal static double PumpBudgetRunCapMs => 12.0;
+        internal static double PumpBudgetFastCapMs => 18.0;
+        internal static double PumpTailMinRunMs => 4.0;
+        internal static double PumpTailMinFastMs => 6.0;
+        internal static double PumpPauseTrickleMapMs => 6.0;
+        internal static double PumpPauseTrickleMenuMs => 2.0;
         internal static double MapScreenProbeDtThresholdMs => 12.0;
         internal static double MapHotDurationMsThreshold => 1.0;
         internal static long MapHotAllocThresholdBytes => 128 * 1024;


### PR DESCRIPTION
## Summary
- gate the small-queue tail burst behind healthy frames and cap budgets through config-driven values
- expose pump caps, tail minimums, and pause trickle durations in MapPerfConfig for easy tuning

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68de3ac46d6c8320acaedfeeef440d5b