### PR TITLE
Tighten spike recovery drain and clamp repeat dedupe bounds

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace MapPerfProbe
 {
@@ -37,10 +38,16 @@ namespace MapPerfProbe
         internal static bool ThrottleOnlyInFastTime => Get(s => s.ThrottleOnlyInFastTime, true);
         internal static bool DesyncSimWhileThrottling => Get(s => s.DesyncSimWhileThrottling, true);
         internal static int SimTickEveryNSkipped => Get(s => s.SimTickEveryNSkipped, 8);
+        internal static bool SilenceRepeats => Get(s => s.SilenceRepeats, true);
+        internal static int RepeatSilenceSeconds => ClampInt(Get(s => s.RepeatSilenceSeconds, 4), 0, 30);
         internal static int MaxDesyncMs => Get(s => s.MaxDesyncMs, 1000);
         internal static int DesyncLowWatermarkMs => Get(s => s.DesyncLowWatermarkMs, 400);
         internal static ThrottlePreset Preset => Get(s => s.Preset, ThrottlePreset.Balanced);
         internal static int PeriodicQueueHardCap => Get(s => s.PeriodicQueueHardCap, 150);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ClampInt(int value, int min, int max)
+            => value < min ? min : (value > max ? max : value);
 
         // Fixed internals (kept sane; not exposed)
         internal static double BudgetAlpha => 0.05;

--- a/MapPerfFix/MapPerfSettings.cs
+++ b/MapPerfFix/MapPerfSettings.cs
@@ -71,6 +71,15 @@ namespace MapPerfProbe
             }
         }
 
+        // -------- Message dedup ----------
+        [SettingPropertyGroup("Message Filters", GroupOrder = 10)]
+        [SettingPropertyBool("Silence immediate repeats", Order = -2)]
+        public bool SilenceRepeats { get; set; } = true;
+
+        [SettingPropertyGroup("Message Filters")]
+        [SettingPropertyInteger("Repeat silence window (seconds)", 0, 30, RequireRestart = false, Order = -1)]
+        public int RepeatSilenceSeconds { get; set; } = 4;
+
         // -------- Message Filters ----------
         [SettingPropertyGroup("Message Filters", GroupOrder = 10)]
         [SettingPropertyBool("Silence: Raids", Order = 0)]


### PR DESCRIPTION
## Summary
- make the repeat-suppression cache case-insensitive so format variants are deduped
- trigger a short BoostDrain burst when the spike guard clears throttling to prevent backlog stalls
- clamp desync debt after spike recovery so the next frame cannot immediately schedule a catch-up
- collapse repeated whitespace before dedupe using a cached, culture-invariant regex so near-duplicates share the same suppression key without per-call allocations
- clear the repeat-dedupe cache whenever map context toggles so stale entries do not linger between modes
- clamp the repeat silence window to a 0–30 second range and shrink the dedupe cache cap to 1k entries to keep memory growth bounded
- replace Math.Clamp with a local inline helper so the build remains compatible with Bannerlord's .NET 4.7.2 runtime
- reset the repeat filter counter when clearing the dedupe cache so HUD stats stay in sync after map transitions

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df038b901083208a7ef4d9e08ac6fb