### PR TITLE
fix: suppress slicer pump after spikes

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -43,7 +43,7 @@ namespace MapPerfProbe
         internal static int MaxDesyncMs => Get(s => s.MaxDesyncMs, 1000);
         internal static int DesyncLowWatermarkMs => Get(s => s.DesyncLowWatermarkMs, 400);
         internal static ThrottlePreset Preset => Get(s => s.Preset, ThrottlePreset.Balanced);
-        internal static int PeriodicQueueHardCap => Get(s => s.PeriodicQueueHardCap, 150);
+        internal static int PeriodicQueueHardCap => Get(s => s.PeriodicQueueHardCap, 300);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int ClampInt(int value, int min, int max)
@@ -64,16 +64,19 @@ namespace MapPerfProbe
         internal static long ForceFlushAllocBytes => 300_000_000;
         internal static long ForceFlushWsBytes => 500_000_000;
         internal static double PumpBudgetRunMs => 3.0;
-        internal static double PumpBudgetFastMs => 8.0;
+        internal static double PumpBudgetFastMs => 6.0;
         internal static double PumpBudgetRunBoostMs => 4.0;
         internal static double PumpBudgetFastBoostMs => 24.0;
         internal static int PumpBacklogBoostThreshold => 1_000;
         internal static double PumpBudgetRunCapMs => 12.0;
-        internal static double PumpBudgetFastCapMs => 18.0;
+        internal static double PumpBudgetFastCapMs => 12.0;
         internal static double PumpTailMinRunMs => 4.0;
-        internal static double PumpTailMinFastMs => 6.0;
-        internal static double PumpPauseTrickleMapMs => 6.0;
+        internal static double PumpTailMinFastMs => 4.0;
+        // Do not pump while paused; stutters came from paused pumping + GC
+        internal static double PumpPauseTrickleMapMs => 0.0;
         internal static double PumpPauseTrickleMenuMs => 2.0;
+        // How long to suppress pumping after a >= SpikeRunMs frame
+        internal static double PostSpikeNoPumpSec => 1.50;
         internal static double MapScreenProbeDtThresholdMs => 12.0;
         internal static double MapHotDurationMsThreshold => 1.0;
         internal static long MapHotAllocThresholdBytes => 128 * 1024;

--- a/MapPerfFix/MapPerfSettings.cs
+++ b/MapPerfFix/MapPerfSettings.cs
@@ -51,8 +51,8 @@ namespace MapPerfProbe
         public bool ThrottleOnlyInFastTime { get; set; } = true;
 
         [SettingPropertyGroup("Map Throttle", GroupOrder = 1)]
-        [SettingPropertyInteger("Periodic queue hard cap", 50, 500, RequireRestart = false, Order = 7)]
-        public int PeriodicQueueHardCap { get; set; } = 150;
+        [SettingPropertyInteger("Periodic queue hard cap", 50, 2000, RequireRestart = false, Order = 7)]
+        public int PeriodicQueueHardCap { get; set; } = 300;
 
         // NOTE: To stay compatible with all MCM v5 variants (no Dropdown<T> / no SettingPropertyEnum),
         // expose an integer and map it to the enum.


### PR DESCRIPTION
## Summary
- stop the periodic slicer from pumping while paused and add a post-spike cooldown window
- extend the forced catch-up cooldown to avoid immediate re-throttling after a long frame
- raise the periodic queue hard cap default so heavy bursts stop falling back inline
- lower fast pump budgets, caps, and treat >=45 ms frames as over budget to clamp post-spike pumping longer

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68df208b756c83209247b4e4a5551518