### PR TITLE
feat: defer periodic hubs during hot map frames

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -37,6 +37,7 @@ namespace MapPerfProbe
         internal static bool EnableMapThrottle => Get(s => s.EnableMapThrottle, true);
         internal static bool ThrottleOnlyInFastTime => Get(s => s.ThrottleOnlyInFastTime, true);
         internal static bool DesyncSimWhileThrottling => Get(s => s.DesyncSimWhileThrottling, true);
+        internal static bool DeferPeriodicOnMap => Get(s => s.DeferPeriodicOnMap, true);
         internal static int SimTickEveryNSkipped => Get(s => s.SimTickEveryNSkipped, 8);
         internal static bool SilenceRepeats => Get(s => s.SilenceRepeats, true);
         internal static int RepeatSilenceSeconds => ClampInt(Get(s => s.RepeatSilenceSeconds, 4), 0, 30);

--- a/MapPerfFix/MapPerfFix.csproj
+++ b/MapPerfFix/MapPerfFix.csproj
@@ -95,6 +95,7 @@
   <ItemGroup>
     <Compile Include="MapPerfConfig.cs" />
     <Compile Include="MapPerfLog.cs" />
+    <Compile Include="PeriodicHubDeferrer.cs" />
     <Compile Include="MapPerfSettings.cs" />
     <Compile Include="MsgFilter.cs" />
     <Compile Include="SubModule.cs" />

--- a/MapPerfFix/MapPerfSettings.cs
+++ b/MapPerfFix/MapPerfSettings.cs
@@ -54,6 +54,10 @@ namespace MapPerfProbe
         [SettingPropertyInteger("Periodic queue hard cap", 50, 2000, RequireRestart = false, Order = 7)]
         public int PeriodicQueueHardCap { get; set; } = 300;
 
+        [SettingPropertyGroup("Map Throttle", GroupOrder = 1)]
+        [SettingPropertyBool("Defer ALL periodic ticks on map (safer, no spikes)", Order = 8)]
+        public bool DeferPeriodicOnMap { get; set; } = true;
+
         // NOTE: To stay compatible with all MCM v5 variants (no Dropdown<T> / no SettingPropertyEnum),
         // expose an integer and map it to the enum.
         [SettingPropertyGroup("Map Throttle", GroupOrder = 1)]

--- a/MapPerfFix/PeriodicHubDeferrer.cs
+++ b/MapPerfFix/PeriodicHubDeferrer.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+
+namespace MapPerfProbe
+{
+    /// <summary>
+    /// Defers periodic hubs into the slicer when frames are hot.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class PeriodicHubDeferrer
+    {
+        [ThreadStatic] private static bool _reentry;
+
+        private static bool HotNow()
+        {
+            if (!SubModule.IsOnMap())
+                return false;
+            if (MapPerfConfig.DeferPeriodicOnMap)
+                return true;
+            if (SubModule.FastSnapshot)
+                return true;
+            return SubModule.HotOrRecent();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ShouldDefer()
+            => MapPerfConfig.Enabled && !_reentry && HotNow();
+
+        private static readonly ConcurrentDictionary<MethodBase, bool> _foreignCache = new();
+
+        private static bool HasForeignPatches(MethodBase method)
+        {
+            if (method == null)
+                return false;
+
+            return _foreignCache.GetOrAdd(method, static key =>
+            {
+                try
+                {
+                    var info = Harmony.GetPatchInfo(key);
+                    if (info == null)
+                        return false;
+
+                    static bool HasNonSelf(IEnumerable<Patch> patches)
+                    {
+                        if (patches == null)
+                            return false;
+                        foreach (var patch in patches)
+                        {
+                            if (patch == null)
+                                continue;
+                            if (!string.Equals(patch.owner, SubModule.HarmonyId, StringComparison.Ordinal))
+                                return true;
+                        }
+
+                        return false;
+                    }
+
+                    return HasNonSelf(info.Prefixes)
+                           || HasNonSelf(info.Postfixes)
+                           || HasNonSelf(info.Transpilers)
+                           || HasNonSelf(info.Finalizers);
+                }
+                catch
+                {
+                    return false;
+                }
+            });
+        }
+
+        private static bool MatchesPeriodic(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return false;
+            // Never touch accessors/events.
+            if (name.StartsWith("get_", StringComparison.Ordinal)
+                || name.StartsWith("set_", StringComparison.Ordinal)
+                || name.StartsWith("add_", StringComparison.Ordinal)
+                || name.StartsWith("remove_", StringComparison.Ordinal))
+            {
+                return false;
+            }
+            return name.IndexOf("Tick", StringComparison.OrdinalIgnoreCase) >= 0
+                   || name.IndexOf("Hourly", StringComparison.OrdinalIgnoreCase) >= 0
+                   || name.IndexOf("Daily", StringComparison.OrdinalIgnoreCase) >= 0
+                   || name.IndexOf("Weekly", StringComparison.OrdinalIgnoreCase) >= 0
+                   || name.IndexOf("Quarter", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        [HarmonyTargetMethods]
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            var hubTypeNames = new HashSet<string>
+            {
+                "TaleWorlds.CampaignSystem.CampaignPeriodicEventManager",
+                "TaleWorlds.CampaignSystem.CampaignEventDispatcher"
+            };
+
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] types;
+                try { types = asm.GetTypes(); }
+                catch { continue; }
+
+                foreach (var t in types)
+                {
+                    if (t?.FullName == null || !hubTypeNames.Contains(t.FullName))
+                        continue;
+
+                    foreach (var m in t.GetMethods(BindingFlags.Instance | BindingFlags.Static |
+                                                   BindingFlags.Public | BindingFlags.NonPublic))
+                    {
+                        if (m == null)
+                            continue;
+                        if (m.IsAbstract || m.IsConstructor || m.IsSpecialName)
+                            continue;
+                        if (m.ContainsGenericParameters)
+                            continue;
+                        if (m.MethodImplementationFlags.HasFlag(MethodImplAttributes.InternalCall))
+                            continue;
+                        // Only periodic-looking, void-returning, and NO by-ref params.
+                        if (!MatchesPeriodic(m.Name))
+                            continue;
+
+                        var mi = m as MethodInfo;
+                        if (mi == null || mi.ReturnType != typeof(void))
+                            continue;
+
+                        var ps = mi.GetParameters();
+                        bool hasByRef = false;
+                        for (int i = 0; i < ps.Length; i++)
+                        {
+                            if (ps[i].ParameterType.IsByRef)
+                            {
+                                hasByRef = true;
+                                break;
+                            }
+                        }
+
+                        if (!hasByRef)
+                            yield return mi;
+                    }
+                }
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.VeryHigh)]
+        static bool Prefix(object __instance, MethodBase __originalMethod, object[] __args)
+        {
+            if (__originalMethod == null)
+                return true;
+            // Safety: don’t defer non-void (should be filtered already).
+            if ((__originalMethod as MethodInfo)?.ReturnType != typeof(void))
+                return true;
+            // Safety: don’t defer if any by-ref slipped through.
+            var ps = __originalMethod.GetParameters();
+            for (int i = 0; i < ps.Length; i++)
+            {
+                if (ps[i].ParameterType.IsByRef)
+                    return true;
+            }
+            if (!MapPerfConfig.DeferPeriodicOnMap && HasForeignPatches(__originalMethod))
+            {
+                if (MapPerfConfig.DebugLogging && SubModule.ShouldLogSlow("hub-deferrer-foreign-skip", 5.0))
+                {
+                    MapPerfLog.Info($"[hub-deferrer] foreign patches on {__originalMethod.DeclaringType?.Name}.{__originalMethod.Name}; skipping defer");
+                }
+                return true;
+            }
+            if (!ShouldDefer())
+                return true;
+            if (!SubModule.MayEnqueueNow())
+                return true;
+
+            // Use bool-returning enqueue to safely fall back inline if the queue refuses us.
+            bool enq = PeriodicSlicer.EnqueueAction(() =>
+            {
+                _reentry = true;
+                try
+                {
+                    __originalMethod.Invoke(__instance, __args);
+                }
+                catch (TargetInvocationException tie)
+                {
+                    var inner = tie.InnerException?.Message ?? tie.Message;
+                    MapPerfLog.Warn($"[hub-deferrer] {__originalMethod.DeclaringType?.Name}.{__originalMethod.Name} threw: {inner}");
+                }
+                catch (Exception ex)
+                {
+                    MapPerfLog.Warn($"[hub-deferrer] {__originalMethod.DeclaringType?.Name}.{__originalMethod.Name} threw: {ex.Message}");
+                }
+                finally
+                {
+                    _reentry = false;
+                }
+            });
+
+            if (!enq)
+            {
+                if (MapPerfConfig.DebugLogging && SubModule.ShouldLogSlow("hub-deferrer-fallback", 5.0))
+                {
+                    MapPerfLog.Info($"[hub-deferrer] queue closed; running inline {__originalMethod.DeclaringType?.Name}.{__originalMethod.Name}");
+                }
+                return true; // queue full or gated; run original now
+            }
+
+            if (MapPerfConfig.DebugLogging && SubModule.ShouldLogSlow("hub-deferrer", 5.0))
+            {
+                MapPerfLog.Info($"[hub-deferrer] deferred {__originalMethod.DeclaringType?.Name}.{__originalMethod.Name}");
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable toggle to defer periodic campaign ticks while on the map
- enqueue periodic hub invocations through a new Harmony deferrer when frames are hot
- ensure the hub deferrer uses Harmony targeting metadata and the existing slicer enqueue guard so it actually runs
- harden the deferrer by limiting patches to void-returning methods and confirming the PatchAll bootstrap includes it
- skip by-ref hub methods, ignore accessors, filter out abstract/constructor/special-name targets, and keep a very-high priority prefix that falls back inline whenever the queue rejects so contracts remain intact
- log inline fallbacks when the queue is closed, reuse the shared HotOrRecent helper so deferrer gating matches the module’s hot signal, skip deferring when foreign patches are present unless the config explicitly forces it, and add debug logging to surface foreign-skip decisions
- cache foreign Harmony audits so repeated calls stay cheap and filter out generic or internal-call hub methods before deferring

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df2d9e33e88320a57cea8f779b4aaf