### PR TITLE
fix: restore C# 7.3 compatibility for hub deferrer

### DIFF
--- a/MapPerfFix/PeriodicHubDeferrer.cs
+++ b/MapPerfFix/PeriodicHubDeferrer.cs
@@ -30,14 +30,15 @@ namespace MapPerfProbe
         private static bool ShouldDefer()
             => MapPerfConfig.Enabled && !_reentry && HotNow();
 
-        private static readonly ConcurrentDictionary<MethodBase, bool> _foreignCache = new();
+        private static readonly ConcurrentDictionary<MethodBase, bool> _foreignCache =
+            new ConcurrentDictionary<MethodBase, bool>();
 
         private static bool HasForeignPatches(MethodBase method)
         {
             if (method == null)
                 return false;
 
-            return _foreignCache.GetOrAdd(method, static key =>
+            return _foreignCache.GetOrAdd(method, key =>
             {
                 try
                 {
@@ -45,7 +46,7 @@ namespace MapPerfProbe
                     if (info == null)
                         return false;
 
-                    static bool HasNonSelf(IEnumerable<Patch> patches)
+                    bool HasNonSelf(IEnumerable<Patch> patches)
                     {
                         if (patches == null)
                             return false;


### PR DESCRIPTION
## Summary
- replace target-typed new, static local functions, and static lambdas in PeriodicHubDeferrer with C# 7.3-compatible constructs to keep the project building under the configured language version

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df3d9cf5e08320bbeb39d9ae834cb1