### PR TITLE
perf(slice): keep draining through cooldowns

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -44,7 +44,7 @@ namespace MapPerfProbe
         internal static int MaxDesyncMs => Get(s => s.MaxDesyncMs, 1000);
         internal static int DesyncLowWatermarkMs => Get(s => s.DesyncLowWatermarkMs, 400);
         internal static ThrottlePreset Preset => Get(s => s.Preset, ThrottlePreset.Balanced);
-        internal static int PeriodicQueueHardCap => Get(s => s.PeriodicQueueHardCap, 300);
+        internal static int PeriodicQueueHardCap => Get(s => s.PeriodicQueueHardCap, 4000);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int ClampInt(int value, int min, int max)
@@ -65,19 +65,19 @@ namespace MapPerfProbe
         internal static long ForceFlushAllocBytes => 300_000_000;
         internal static long ForceFlushWsBytes => 500_000_000;
         internal static double PumpBudgetRunMs => 3.0;
-        internal static double PumpBudgetFastMs => 6.0;
+        internal static double PumpBudgetFastMs => 8.0;
         internal static double PumpBudgetRunBoostMs => 4.0;
-        internal static double PumpBudgetFastBoostMs => 24.0;
-        internal static int PumpBacklogBoostThreshold => 1_000;
+        internal static double PumpBudgetFastBoostMs => 24.0; // keep
+        internal static int PumpBacklogBoostThreshold => 400;
         internal static double PumpBudgetRunCapMs => 12.0;
-        internal static double PumpBudgetFastCapMs => 12.0;
+        internal static double PumpBudgetFastCapMs => 18.0;
         internal static double PumpTailMinRunMs => 4.0;
-        internal static double PumpTailMinFastMs => 4.0;
+        internal static double PumpTailMinFastMs => 6.0;
         // Do not pump while paused; stutters came from paused pumping + GC
         internal static double PumpPauseTrickleMapMs => 0.0;
         internal static double PumpPauseTrickleMenuMs => 2.0;
         // How long to suppress pumping after a >= SpikeRunMs frame
-        internal static double PostSpikeNoPumpSec => 1.50;
+        internal static double PostSpikeNoPumpSec => 0.60;
         internal static double MapScreenProbeDtThresholdMs => 12.0;
         internal static double MapHotDurationMsThreshold => 1.0;
         internal static long MapHotAllocThresholdBytes => 128 * 1024;

--- a/MapPerfFix/MapPerfSettings.cs
+++ b/MapPerfFix/MapPerfSettings.cs
@@ -51,8 +51,8 @@ namespace MapPerfProbe
         public bool ThrottleOnlyInFastTime { get; set; } = true;
 
         [SettingPropertyGroup("Map Throttle", GroupOrder = 1)]
-        [SettingPropertyInteger("Periodic queue hard cap", 50, 2000, RequireRestart = false, Order = 7)]
-        public int PeriodicQueueHardCap { get; set; } = 300;
+        [SettingPropertyInteger("Periodic queue hard cap", 50, 5000, RequireRestart = false, Order = 7)]
+        public int PeriodicQueueHardCap { get; set; } = 4000;
 
         [SettingPropertyGroup("Map Throttle", GroupOrder = 1)]
         [SettingPropertyBool("Defer ALL periodic ticks on map (safer, no spikes)", Order = 8)]


### PR DESCRIPTION
## Summary
- extend the periodic queue cap slider to 5000 with a 4000 default so config overrides can apply when MCM is present
- allow cooldown trickle once backlog reaches the boost threshold and raise fast-time pump throughput to drain large queues faster
- pump and retry periodic hub defers before falling back inline so spikes stay off the frame
- permit emergency fast-time trickle even when the pump cooldown is active so large queues keep draining
- recheck the slicer gate after an emergency pump and include queue stats in the rare inline log to confirm the deferrer is staying off the frame

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df4567993c832080e83fc8bc572c0b