### PR TITLE
Route heavy periodic work to slow lane

### DIFF
--- a/MapPerfFix/PeriodicHubDeferrer.cs
+++ b/MapPerfFix/PeriodicHubDeferrer.cs
@@ -217,12 +217,17 @@ namespace MapPerfProbe
                 }
             };
 
-            bool enq = PeriodicSlicer.EnqueueAction(action);
+            var name = __originalMethod.Name ?? string.Empty;
+            var slow = name.IndexOf("DailyTick", StringComparison.Ordinal) >= 0
+                       || name.IndexOf("Weekly", StringComparison.Ordinal) >= 0
+                       || name.IndexOf("TickPartialHourlyAi", StringComparison.Ordinal) >= 0
+                       || name.IndexOf("AiHourlyTick", StringComparison.Ordinal) >= 0;
+            bool enq = slow ? PeriodicSlicer.EnqueueSlowAction(action) : PeriodicSlicer.EnqueueAction(action);
             if (!enq)
             {
                 PeriodicSlicer.Pump(SubModule.FastSnapshot ? 3.0 : 2.0);
                 if (SubModule.MayEnqueueNow())
-                    enq = PeriodicSlicer.EnqueueAction(action);
+                    enq = slow ? PeriodicSlicer.EnqueueSlowAction(action) : PeriodicSlicer.EnqueueAction(action);
             }
 
             if (!enq)


### PR DESCRIPTION
## Summary
- add a dedicated slow handler lane to the periodic slicer, keeping it out of the fast-time pump while updating queue stats/backpressure
- route heavy campaign and hub ticks (daily/weekly/AI) onto the slow lane so they no longer trigger long fast-time drains
- keep Campaign.DailyTick deferrals on the slow lane while still respecting the bypass gate
- classify heavy batched handlers onto the slow lane to prevent fast-time overshoots
- harden the zero-param resolver so Harmony lookups succeed even when direct reflection fails

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68df4e8c6bb08320a0fc3ef3019234ba