### PR TITLE
fix: restore pump timestamp capture

### DIFF
--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -5059,6 +5059,7 @@ namespace MapPerfProbe
 
             int remaining;
             lock (_lock) remaining = _qHandlers.Count + _qHandlersSlow.Count;
+            var now = Stopwatch.GetTimestamp();
             var overshootMs = overshoot * SubModule.TicksToMs;
 
             if (overshoot > 0)


### PR DESCRIPTION
## Summary
- capture the current timestamp before logging pump statistics

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df677c7e2c8320af14a06955bf04d8