### PR TITLE
Fix pump cooldown stalls

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -73,11 +73,11 @@ namespace MapPerfProbe
         internal static double PumpBudgetFastCapMs => 18.0;
         internal static double PumpTailMinRunMs => 4.0;
         internal static double PumpTailMinFastMs => 6.0;
-        // Do not pump while paused; stutters came from paused pumping + GC
-        internal static double PumpPauseTrickleMapMs => 0.0;
+        // always progress, even when paused
+        internal static double PumpPauseTrickleMapMs => 2.0;
         internal static double PumpPauseTrickleMenuMs => 2.0;
-        // How long to suppress pumping after a >= SpikeRunMs frame
-        internal static double PostSpikeNoPumpSec => 0.10;
+        // never suppress the pump; spikes should not stall backlog
+        internal static double PostSpikeNoPumpSec => 0.00;
         internal static double MapScreenProbeDtThresholdMs => 12.0;
         internal static double MapHotDurationMsThreshold => 1.0;
         internal static long MapHotAllocThresholdBytes => 128 * 1024;

--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -5034,7 +5034,7 @@ namespace MapPerfProbe
             var inCooldownTrickle = false;
             if (Stopwatch.GetTimestamp() < Volatile.Read(ref _pumpCooldownUntil))
             {
-                // allow a tiny trickle even during cooldown in RUN and FAST
+                // always drain a bit if there's backlog (RUN or FAST)
                 if (QueueLength == 0) return;
                 msBudget = Math.Min(msBudget, SubModule.FastSnapshot ? 3.0 : 2.0);
                 inCooldownTrickle = true;


### PR DESCRIPTION
## Summary
- restore the map pause trickle so the backlog drains even while paused
- disable the post-spike pump suppression and clarify the cooldown trickle comment

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68df85913ffc83209f3f694f75690a75