### PR TITLE
Fix slicer cooldown and fast-lane pump overshoot

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -74,10 +74,10 @@ namespace MapPerfProbe
         internal static double PumpTailMinRunMs => 4.0;
         internal static double PumpTailMinFastMs => 6.0;
         // always progress, even when paused
-        internal static double PumpPauseTrickleMapMs => 2.0;
+        internal static double PumpPauseTrickleMapMs => 1.5;
         internal static double PumpPauseTrickleMenuMs => 2.0;
         // never suppress the pump; spikes should not stall backlog
-        internal static double PostSpikeNoPumpSec => 0.00;
+        internal static double PostSpikeNoPumpSec => 0.10;
         internal static double MapScreenProbeDtThresholdMs => 12.0;
         internal static double MapHotDurationMsThreshold => 1.0;
         internal static long MapHotAllocThresholdBytes => 128 * 1024;


### PR DESCRIPTION
## Summary
- add PeriodicSlicer.BreakCooldown so campaign daily guards can clear the pump cooldown gate
- clamp RUN-FAST pump batches to a single item (including cooldown trickle) to stop overshoot bursts
- always release the Improved Garrison SLA stamp once its tick runs so the overdue gate resets cleanly

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68df8ff06b188320ab5e2ee3e9564008