### PR TITLE
Fix idle probe campaign API references

### DIFF
--- a/MapPerfFix/MapIdleDrainProbe.cs
+++ b/MapPerfFix/MapIdleDrainProbe.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace MapPerfProbe
 {
@@ -229,9 +231,9 @@ namespace MapPerfProbe
 
                 _samples++;
 
-                _sumParties += SafeCount(TaleWorlds.CampaignSystem.Party.MobileParty.All);
-                _sumArmies += SafeCount(TaleWorlds.CampaignSystem.Army.Armies);
-                _sumSettlements += SafeCount(TaleWorlds.CampaignSystem.Settlement.All);
+                _sumParties += SafeCount(MobileParty.All);
+                _sumArmies += CountArmies();
+                _sumSettlements += SafeCount(Settlement.All);
 
                 var tracks = EstimateTrackCount(campaign);
                 if (tracks > 0)
@@ -240,6 +242,28 @@ namespace MapPerfProbe
             catch
             {
                 // ignore – diagnostics only
+            }
+        }
+
+        private static int CountArmies()
+        {
+            try
+            {
+                var kingdoms = Kingdom.All;
+                if (kingdoms == null) return 0;
+
+                var total = 0;
+                foreach (var kingdom in kingdoms)
+                {
+                    if (kingdom == null) continue;
+                    total += SafeCount(kingdom.Armies);
+                }
+
+                return total;
+            }
+            catch
+            {
+                return 0;
             }
         }
 


### PR DESCRIPTION
## Summary
- use the proper TaleWorlds namespaces for mobile parties and settlements
- count active armies by summing kingdom army collections instead of the removed Army.Armies API

## Testing
- not run (per instructions)

Rationale: Restore compatibility with current Bannerlord assemblies.
Risk: Low; changes only touch diagnostics and guard failures with try/catch.

------
https://chatgpt.com/codex/tasks/task_e_68df9f1ea5b883208a29756e1faca076