### PR TITLE
fix(probe): guard mapstate metrics and rebalance gl budget

### DIFF
--- a/MapPerfFix/MapIdleDrainProbe.cs
+++ b/MapPerfFix/MapIdleDrainProbe.cs
@@ -6,8 +6,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
-using TaleWorlds.CampaignSystem.Party;
-using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Party;        // MobileParty.All
+using TaleWorlds.CampaignSystem.Settlements;  // Settlement.All
 
 namespace MapPerfProbe
 {
@@ -39,14 +39,85 @@ namespace MapPerfProbe
         private static readonly double TicksToMs = 1000.0 / Stopwatch.Frequency;
         private static readonly double TicksToSeconds = 1.0 / Stopwatch.Frequency;
 
+        private sealed class Metric
+        {
+            private const int Cap = 8192;
+            private readonly double[] _buf = new double[Cap];
+            private int _n;
+            public long Count;
+            public double Sum;
+            public double Max;
+            public int SampleCount => _n;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Add(double v)
+            {
+                if (v < 0) return;
+                Sum += v;
+                Count++;
+                if (v > Max) Max = v;
+                if (_n < Cap) _buf[_n++] = v;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void RecordMax(double v)
+            {
+                if (v < 0) return;
+                Count++;
+                if (v > Max) Max = v;
+                if (_n < Cap) _buf[_n++] = v;
+            }
+
+            public double Avg => Count > 0 ? Sum / Count : 0.0;
+
+            public double P95()
+            {
+                var n = _n;
+                if (n == 0) return 0.0;
+                Array.Sort(_buf, 0, n);
+                var idx = (int)Math.Round(0.95 * (n - 1));
+                if (idx < 0) idx = 0;
+                if (idx >= n) idx = n - 1;
+                return _buf[idx];
+            }
+
+            public int CountAbove(double threshold)
+            {
+                var n = _n;
+                if (n == 0) return 0;
+                var count = 0;
+                for (var i = 0; i < n; i++)
+                {
+                    if (_buf[i] >= threshold)
+                        count++;
+                }
+                return count;
+            }
+
+            public void Reset()
+            {
+                Count = 0;
+                Sum = 0;
+                Max = 0;
+                _n = 0;
+            }
+        }
+
         private static bool _installed;
         private static long _mapFrameStart;
         private static long _uiStart;
+        private static long _msStart;
+        private static long _campStart;
+        private static long _glStart;
         private static long _frames;
         private static long _uiFrames;
-        private static double _accMapFrameMs;
+        private static double _windowStartSec;
+        private static readonly Metric _mMap = new Metric();
+        private static readonly Metric _mUI = new Metric();
+        private static readonly Metric _mMS = new Metric();
+        private static readonly Metric _mCamp = new Metric();
+        private static readonly Metric _mGL = new Metric(); // Gauntlet tracks per-window peak; Avg is not used
         private static double _maxMapFrameMs;
-        private static double _accUiMs;
         private static double _maxUiMs;
         private static long _samples;
         private static long _sumParties;
@@ -58,6 +129,7 @@ namespace MapPerfProbe
         private static int _lastGc1;
         private static int _lastGc2;
         private static long _lastWorkingSetMb;
+        private static bool _msTickSeenThisFrame;
 
         private static readonly ConcurrentDictionary<Type, Func<object, int>> CountResolvers =
             new ConcurrentDictionary<Type, Func<object, int>>();
@@ -77,10 +149,18 @@ namespace MapPerfProbe
                 var mapStateType = Type.GetType("TaleWorlds.CampaignSystem.GameState.MapState, TaleWorlds.CampaignSystem", false)
                                    ?? Type.GetType("TaleWorlds.CampaignSystem.MapState, TaleWorlds.CampaignSystem", false);
                 var uiType = ResolveUiContextType();
+                var campaignType = Type.GetType("TaleWorlds.CampaignSystem.Campaign, TaleWorlds.CampaignSystem", false);
+                var gauntletLayerType = Type.GetType("TaleWorlds.GauntletUI.GauntletLayer, TaleWorlds.GauntletUI", false);
                 var prefix = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(MapFramePrefix));
                 var postfix = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(MapFramePostfix));
                 var uiPrefix = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(UiUpdatePrefix));
                 var uiPostfix = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(UiUpdatePostfix));
+                var msPre = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(MapStateTickPrefix));
+                var msPost = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(MapStateTickPostfix));
+                var campPre = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(CampaignRealTickPrefix));
+                var campPost = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(CampaignRealTickPostfix));
+                var glPre = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(GauntletLayerLateUpdatePrefix));
+                var glPost = AccessTools.Method(typeof(MapIdleDrainProbe), nameof(GauntletLayerLateUpdatePostfix));
 
                 var ht = harmony.GetType();
                 var harmonyAsm = ht.Assembly;
@@ -109,17 +189,23 @@ namespace MapPerfProbe
                     }
                 }
 
-                if (mapStateType != null && prefix != null && postfix != null)
+                if (mapStateType != null && msPre != null && msPost != null)
                 {
                     var msOnMapMode = mapStateType.GetMethod("OnMapModeTick", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                     var msOnTick = mapStateType.GetMethod("OnTick", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                    var target = msOnMapMode ?? msOnTick;
-                    if (target != null)
+                    if (msOnMapMode != null)
                     {
-                        var preHm = hmCtor.Invoke(new object[] { prefix });
-                        var postHm = hmCtor.Invoke(new object[] { postfix });
-                        try { patchMi.Invoke(harmony, new object[] { target, preHm, postHm, null, null }); }
-                        catch (Exception ex) { MapPerfLog.Error("[idle-probe] patch MapState.* failed", ex); }
+                        var preHm = hmCtor.Invoke(new object[] { msPre });
+                        var postHm = hmCtor.Invoke(new object[] { msPost });
+                        try { patchMi.Invoke(harmony, new object[] { msOnMapMode, preHm, postHm, null, null }); }
+                        catch (Exception ex) { MapPerfLog.Error("[idle-probe] patch MapState.OnMapModeTick failed", ex); }
+                    }
+                    if (msOnTick != null)
+                    {
+                        var preHm = hmCtor.Invoke(new object[] { msPre });
+                        var postHm = hmCtor.Invoke(new object[] { msPost });
+                        try { patchMi.Invoke(harmony, new object[] { msOnTick, preHm, postHm, null, null }); }
+                        catch (Exception ex) { MapPerfLog.Error("[idle-probe] patch MapState.OnTick failed", ex); }
                     }
                 }
 
@@ -136,6 +222,32 @@ namespace MapPerfProbe
                     else
                     {
                         MapPerfLog.Warn("[idle-probe] UIContext.Update not found; idle drain probe UI timing disabled.");
+                    }
+                }
+
+                if (campaignType != null && campPre != null && campPost != null)
+                {
+                    var realTick = campaignType.GetMethod("RealTick", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    if (realTick != null)
+                    {
+                        var preHm = hmCtor.Invoke(new object[] { campPre });
+                        var postHm = hmCtor.Invoke(new object[] { campPost });
+                        try { patchMi.Invoke(harmony, new object[] { realTick, preHm, postHm, null, null }); }
+                        catch (Exception ex) { MapPerfLog.Error("[idle-probe] patch Campaign.RealTick failed", ex); }
+                    }
+                }
+
+                if (gauntletLayerType != null && glPre != null && glPost != null)
+                {
+                    var lateUpdate = gauntletLayerType.GetMethod("OnLateUpdate", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                                   ?? gauntletLayerType.GetMethod("Update", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                                   ?? gauntletLayerType.GetMethod("Tick", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    if (lateUpdate != null)
+                    {
+                        var preHm = hmCtor.Invoke(new object[] { glPre });
+                        var postHm = hmCtor.Invoke(new object[] { glPost });
+                        try { patchMi.Invoke(harmony, new object[] { lateUpdate, preHm, postHm, null, null }); }
+                        catch (Exception ex) { MapPerfLog.Error("[idle-probe] patch GauntletLayer.* failed", ex); }
                     }
                 }
 
@@ -157,9 +269,13 @@ namespace MapPerfProbe
         {
             _frames = 0;
             _uiFrames = 0;
-            _accMapFrameMs = 0.0;
+            _windowStartSec = Stopwatch.GetTimestamp() * TicksToSeconds;
+            _mMap.Reset();
+            _mUI.Reset();
+            _mMS.Reset();
+            _mCamp.Reset();
+            _mGL.Reset();
             _maxMapFrameMs = 0.0;
-            _accUiMs = 0.0;
             _maxUiMs = 0.0;
             _samples = 0;
             _sumParties = 0;
@@ -167,6 +283,7 @@ namespace MapPerfProbe
             _sumSettlements = 0;
             _sumTracks = 0;
             _nextReportSec = 0.0;
+            _msTickSeenThisFrame = false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -193,6 +310,7 @@ namespace MapPerfProbe
 
         private static void MapFramePrefix(object __instance)
         {
+            _msTickSeenThisFrame = false;
             if (!ShouldSample())
             {
                 _mapFrameStart = 0;
@@ -210,7 +328,7 @@ namespace MapPerfProbe
 
             var ticks = Stopwatch.GetTimestamp() - start;
             var dtMs = ticks * TicksToMs;
-            _accMapFrameMs += dtMs;
+            _mMap.Add(dtMs);
             if (dtMs > _maxMapFrameMs) _maxMapFrameMs = dtMs;
             _frames++;
 
@@ -236,12 +354,76 @@ namespace MapPerfProbe
             _uiStart = 0;
 
             var dtMs = (Stopwatch.GetTimestamp() - start) * TicksToMs;
-            _accUiMs += dtMs;
+            _mUI.Add(dtMs);
             if (dtMs > _maxUiMs) _maxUiMs = dtMs;
             _uiFrames++;
             // also sample world state during UI-only windows so world counts are non-zero
             SampleWorldState(null);
             MaybeReport();
+        }
+
+        private static void MapStateTickPrefix(object __instance)
+        {
+            if (!ShouldSample() || _msTickSeenThisFrame)
+            {
+                _msStart = 0;
+                return;
+            }
+
+            _msStart = Stopwatch.GetTimestamp();
+        }
+
+        private static void MapStateTickPostfix(object __instance)
+        {
+            var start = _msStart;
+            if (start == 0) return;
+            _msStart = 0;
+
+            var dtMs = (Stopwatch.GetTimestamp() - start) * TicksToMs;
+            _mMS.Add(dtMs);
+            _msTickSeenThisFrame = true;
+        }
+
+        private static void CampaignRealTickPrefix(object __instance)
+        {
+            if (!ShouldSample())
+            {
+                _campStart = 0;
+                return;
+            }
+
+            _campStart = Stopwatch.GetTimestamp();
+        }
+
+        private static void CampaignRealTickPostfix(object __instance)
+        {
+            var start = _campStart;
+            if (start == 0) return;
+            _campStart = 0;
+
+            var dtMs = (Stopwatch.GetTimestamp() - start) * TicksToMs;
+            _mCamp.Add(dtMs);
+        }
+
+        private static void GauntletLayerLateUpdatePrefix(object __instance)
+        {
+            if (!ShouldSample())
+            {
+                _glStart = 0;
+                return;
+            }
+
+            _glStart = Stopwatch.GetTimestamp();
+        }
+
+        private static void GauntletLayerLateUpdatePostfix(object __instance)
+        {
+            var start = _glStart;
+            if (start == 0) return;
+            _glStart = 0;
+
+            var dtMs = (Stopwatch.GetTimestamp() - start) * TicksToMs;
+            _mGL.RecordMax(dtMs);
         }
 
         private static void SampleWorldState(object mapScreen)
@@ -298,12 +480,23 @@ namespace MapPerfProbe
             if (nowSec < _nextReportSec) return;
             _nextReportSec = nowSec + ReportIntervalSeconds;
 
+            var windowSec = Math.Max(1e-6, nowSec - _windowStartSec);
             var mapFrames = _frames;
             var uiFrames = _uiFrames;
-            var mapCount = Math.Max(1L, mapFrames);
-            var uiCount = Math.Max(1L, uiFrames);
-            var avgMapMs = _accMapFrameMs / mapCount;
-            var avgUiMs = _accUiMs / uiCount;
+            // FPS derives from map frames when present; UI-only windows fall back to UI frames.
+            var fps = mapFrames > 0 ? mapFrames / windowSec : uiFrames / windowSec;
+            // Require enough window time and map frames before classifying low FPS to avoid UI-only false positives.
+            var canJudgeFps = windowSec >= 2.0 && mapFrames >= Math.Max(30, (int)(20 * windowSec));
+            var avgMapMs = _mMap.Avg;
+            var avgUiMs = _mUI.Avg;
+            var avgMsTick = _mMS.Avg;
+            var avgCamp = _mCamp.Avg;
+            var p95Map = _mMap.P95();
+            var p95Ui = _mUI.P95();
+            var p95Ms = _mMS.P95();
+            var p95Camp = _mCamp.P95();
+            var p95Gl = _mGL.P95();
+            var totalMapSamples = Math.Max(1, _mMap.SampleCount);
             var avgParties = _samples > 0 ? (double)_sumParties / _samples : 0.0;
             var avgArmies = _samples > 0 ? (double)_sumArmies / _samples : 0.0;
             var avgSettlements = _samples > 0 ? (double)_sumSettlements / _samples : 0.0;
@@ -328,8 +521,40 @@ namespace MapPerfProbe
             PublishSnapshot(mapFrames, avgMapMs, _maxMapFrameMs, avgUiMs, _maxUiMs,
                 avgParties, avgArmies, avgSettlements, avgTracks, d0, d1, d2, ws, deltaWs, mode);
 
-            MapPerfLog.Info(
-                $"[idle-probe] mode={mode} frames={mapFrames} avg_map_ms={avgMapMs:F2} max_map_ms={_maxMapFrameMs:F2} avg_ui_ms={avgUiMs:F2} max_ui_ms={_maxUiMs:F2} | world≈ parties={avgParties:F0} armies={avgArmies:F0} settlements={avgSettlements:F0} tracks={avgTracks:F0} | GCΔ G0={d0} G1={d1} G2={d2} | WS={ws}MB (Δ{deltaWs}MB)");
+            var cpuBudgetMs = 1000.0 / Math.Max(1.0, fps);
+            var longPct = _mMap.CountAbove(1.25 * cpuBudgetMs) * 100.0 / totalMapSamples;
+            var veryLongPct = _mMap.CountAbove(2.0 * cpuBudgetMs) * 100.0 / totalMapSamples;
+
+            MapPerfLog.Info(FormattableString.Invariant(
+                $"[idle-probe] mode={mode} fps={fps:F1} frames={mapFrames} ui_frames={uiFrames} avg_map_ms={avgMapMs:F2} p95_map_ms={p95Map:F2} max_map_ms={_maxMapFrameMs:F2} long_frame%={longPct:F1} very_long%={veryLongPct:F1} avg_ui_ms={avgUiMs:F2} p95_ui_ms={p95Ui:F2} | p95_ms={p95Ms:F2} p95_camp={p95Camp:F2} p95_gl={p95Gl:F2} | world≈ parties={avgParties:F0} armies={avgArmies:F0} settlements={avgSettlements:F0} tracks={avgTracks:F0} | GCΔ G0={d0} G1={d1} G2={d2} | WS={ws}MB (Δ{deltaWs}MB)"));
+
+            var managedLoadMs = avgMapMs + avgUiMs + avgMsTick + avgCamp + p95Gl;
+            string DetermineCause()
+            {
+                if (p95Map > 8.0 || p95Ms > 8.0) return "MapState/MapScreen";
+                if (p95Camp > 6.0) return "Campaign.RealTick";
+                if (p95Gl > 6.0 || p95Ui > 4.0) return "UI/Gauntlet";
+                if (managedLoadMs < 0.5 * cpuBudgetMs) return "engine/render (outside managed)";
+                return "mixed";
+            }
+
+            if (canJudgeFps && fps < 55.0)
+            {
+                var cause = DetermineCause();
+                if (d1 > 0 || d2 > 0)
+                    cause += " + GC";
+                MapPerfLog.Warn(FormattableString.Invariant(
+                    $"[idle-probe][low-fps] fps={fps:F1} frames={mapFrames} ui_frames={uiFrames} budget_ms≈{cpuBudgetMs:F1} managed_load_ms≈{managedLoadMs:F1} cause={cause} p95 map={p95Map:F1} ms={p95Ms:F1} camp={p95Camp:F1} ui={p95Ui:F1} gl={p95Gl:F1} | GCΔ G0={d0} G1={d1} G2={d2} WSΔ={deltaWs}MB"));
+            }
+
+            if (mapFrames > 0 && fps >= 55.0 && (p95Map > 2.0 || _maxMapFrameMs > 3.0 * cpuBudgetMs))
+            {
+                var cause = DetermineCause();
+                if (d1 > 0 || d2 > 0)
+                    cause += " + GC";
+                MapPerfLog.Warn(FormattableString.Invariant(
+                    $"[idle-probe][stutter] fps={fps:F1} frames={mapFrames} ui_frames={uiFrames} budget_ms≈{cpuBudgetMs:F1} max_map_ms={_maxMapFrameMs:F1} cause={cause} p95 map={p95Map:F1} ms={p95Ms:F1} camp={p95Camp:F1} ui={p95Ui:F1} gl={p95Gl:F1} | GCΔ G0={d0} G1={d1} G2={d2} WSΔ={deltaWs}MB"));
+            }
 
             ResetWindow();
         }
@@ -370,6 +595,7 @@ namespace MapPerfProbe
             };
 
             _lastSnap = snap;
+            // Ensure consumers observe the populated snapshot before the validity flag flips.
             System.Threading.Volatile.Write(ref _snapValid, 1);
         }
 


### PR DESCRIPTION
## Summary
- prevent duplicate MapState timings when both OnMapModeTick and OnTick fire in the same frame
- compute long-frame percentages from the buffered sample count and expose that count on the metric helper
- align managed-budget math by using Gauntlet p95 contributions instead of the instantaneous max spike
- clarify the Gauntlet peak metric usage and rename the managed-load log field for consistency

## Testing
- Not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dfaead41ec832098460b45fa0e7d42