### PR TITLE
feat(config): add mcm toggles for pause skipper

### DIFF
--- a/MapPerfFix/MapPauseSkipper.cs
+++ b/MapPerfFix/MapPauseSkipper.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+
+namespace MapPerfProbe
+{
+    internal static class MapPauseSkipper
+    {
+        private const string HarmonyId = SubModule.HarmonyId + ".pause-skipper";
+        private static readonly ConcurrentDictionary<(Type Type, string Name), MemberInfo> _boolCache = new();
+        private static Harmony _harmony;
+
+        internal static void Install()
+        {
+            if (_harmony != null) return;
+            try
+            {
+                _harmony = new Harmony(HarmonyId);
+            }
+            catch (Exception ex)
+            {
+                MapPerfLog.Warn($"MapPauseSkipper Harmony init failed: {ex.Message}");
+                _harmony = null;
+                return;
+            }
+
+            TryPatchMapScreenOnFrameTick();
+            TryPatchPartyVisualTicks();
+        }
+
+        private static void TryPatchMapScreenOnFrameTick()
+        {
+            if (_harmony == null) return;
+            try
+            {
+                var mapScreenType = AccessTools.TypeByName("SandBox.View.Map.MapScreen");
+                if (mapScreenType == null) return;
+
+                var method = AccessTools.Method(mapScreenType, "OnFrameTick", new[] { typeof(float) });
+                if (!IsPatchable(method)) return;
+
+                _harmony.Patch(method, prefix: new HarmonyMethod(typeof(MapPauseSkipper), nameof(OnFrameTickPrefix)));
+            }
+            catch (Exception ex)
+            {
+                MapPerfLog.Warn($"MapPauseSkipper MapScreen.OnFrameTick patch failed: {ex.Message}");
+            }
+        }
+
+        private static void TryPatchPartyVisualTicks()
+        {
+            if (_harmony == null) return;
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] types;
+                try
+                {
+                    types = asm.GetTypes();
+                }
+                catch (ReflectionTypeLoadException e)
+                {
+                    types = e.Types.Where(t => t != null).ToArray();
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var type in types)
+                {
+                    var fullName = type?.FullName;
+                    if (string.IsNullOrEmpty(fullName)) continue;
+                    if (!fullName.Contains("SandBox.View.Map")) continue;
+                    if (!(fullName.Contains("PartyVisual") || fullName.Contains("ArmyVisual"))) continue;
+
+                    MethodInfo method = null;
+                    try
+                    {
+                        method = AccessTools.Method(type, "Tick", new[] { typeof(float) });
+                    }
+                    catch
+                    {
+                        // Ignore and continue
+                    }
+                    if (!IsPatchable(method)) continue;
+
+                    try
+                    {
+                        _harmony.Patch(method, prefix: new HarmonyMethod(typeof(MapPauseSkipper), nameof(PartyVisualTickPrefix)));
+                    }
+                    catch (Exception ex)
+                    {
+                        MapPerfLog.Warn($"MapPauseSkipper {fullName}.Tick patch failed: {ex.Message}");
+                    }
+                }
+            }
+        }
+
+        private static bool IsPatchable(MethodInfo method)
+        {
+            if (method == null) return false;
+            if (method.IsAbstract) return false;
+            if (method.ContainsGenericParameters) return false;
+            if (method.IsSpecialName) return false;
+            return method.GetMethodBody() != null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool OnFrameTickPrefix()
+            => !(MapPerfConfig.HardPauseSkip && IsPaused());
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool PartyVisualTickPrefix(object __instance)
+        {
+            if (!IsPaused()) return true;
+            if (!MapPerfConfig.SkipPausedVisuals) return true; // MCM toggle
+
+            try
+            {
+                var type = __instance.GetType();
+                var isHovered = GetBool(type, __instance, "IsHovered") ?? GetBool(type, __instance, "_isHovered") ?? false;
+                var isSelected = GetBool(type, __instance, "IsSelected") ?? GetBool(type, __instance, "_isSelected") ?? false;
+                var isMainParty = GetBool(type, __instance, "IsMainParty") ?? GetBool(type, __instance, "_isMainParty") ?? false;
+                var isTracked = GetBool(type, __instance, "IsTracked") ?? GetBool(type, __instance, "_isTracked") ?? false;
+                if (isHovered || isSelected || isMainParty || isTracked) return true;
+
+                var inFrustum = GetBool(type, __instance, "IsInScreenBounds")
+                                ?? GetBool(type, __instance, "_isInScreenBounds") ?? false;
+                if (inFrustum) return true;
+            }
+            catch
+            {
+                // Ignore and fall through to skip
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsPaused()
+        {
+            var campaign = Campaign.Current;
+            return campaign != null && campaign.TimeControlMode == CampaignTimeControlMode.Stop;
+        }
+
+        private static bool? GetBool(Type type, object instance, string name)
+        {
+            if (type == null) return null;
+            var member = _boolCache.GetOrAdd((type, name), static key =>
+            {
+                var field = AccessTools.Field(key.Type, key.Name);
+                if (field != null && field.FieldType == typeof(bool)) return field;
+
+                var property = AccessTools.Property(key.Type, key.Name);
+                if (property != null && property.PropertyType == typeof(bool)) return property;
+
+                return null;
+            });
+
+            if (member is FieldInfo field)
+            {
+                try
+                {
+                    return (bool)field.GetValue(instance);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            if (member is PropertyInfo property)
+            {
+                try
+                {
+                    var getter = property.GetMethod;
+                    return getter != null ? (bool)getter.Invoke(instance, Array.Empty<object>()) : (bool?)null;
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -34,6 +34,8 @@ namespace MapPerfProbe
 
         internal static bool Enabled => Get(s => s.Enabled, true);
         internal static bool DebugLogging => Get(s => s.DebugLogging, false);
+        internal static bool HardPauseSkip      => Get(s => s.HardPauseSkip, true);
+        internal static bool SkipPausedVisuals  => Get(s => s.SkipPausedVisuals, true);
         internal static bool EnableMapThrottle => Get(s => s.EnableMapThrottle, true);
         internal static bool ThrottleOnlyInFastTime => Get(s => s.ThrottleOnlyInFastTime, true);
         internal static bool DesyncSimWhileThrottling => Get(s => s.DesyncSimWhileThrottling, true);

--- a/MapPerfFix/MapPerfFix.csproj
+++ b/MapPerfFix/MapPerfFix.csproj
@@ -96,6 +96,7 @@
     <Compile Include="MapPerfConfig.cs" />
     <Compile Include="MapIdleDrainProbe.cs" />
     <Compile Include="MapIdleDrainMitigator.cs" />
+    <Compile Include="MapPauseSkipper.cs" />
     <Compile Include="MapPerfLog.cs" />
     <Compile Include="PeriodicHubDeferrer.cs" />
     <Compile Include="MapPerfSettings.cs" />

--- a/MapPerfFix/MapPerfSettings.cs
+++ b/MapPerfFix/MapPerfSettings.cs
@@ -75,6 +75,18 @@ namespace MapPerfProbe
             }
         }
 
+        [SettingPropertyGroup("Map Performance/Pause", GroupOrder = 2)]
+        [SettingPropertyBool("Hard-skip MapScreen while paused",
+            HintText = "Skips MapScreen.OnFrameTick when time is stopped.",
+            RequireRestart = false, Order = 0)]
+        public bool HardPauseSkip { get; set; } = true;
+
+        [SettingPropertyGroup("Map Performance/Pause", GroupOrder = 2)]
+        [SettingPropertyBool("Skip party/army visuals while paused",
+            HintText = "Stops PartyVisual/ArmyVisual Tick except hovered/selected/tracked and on-screen.",
+            RequireRestart = false, Order = 1)]
+        public bool SkipPausedVisuals { get; set; } = true;
+
         // -------- Message dedup ----------
         [SettingPropertyGroup("Message Filters", GroupOrder = 10)]
         [SettingPropertyBool("Silence immediate repeats", Order = -2)]

--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -424,6 +424,7 @@ namespace MapPerfProbe
                 // IMPORTANT: after bootstrapping the deferrer assembly, apply the throttle patch
                 // before broader instrumentation so its bool-prefix can skip the original when needed.
                 SafePatch("PatchMapScreenThrottle", () => PatchMapScreenThrottle(harmony));
+                SafePatch("Install MapPauseSkipper", MapPauseSkipper.Install);
 
                 // High-level map/UI hooks (already working)
                 SafePatch("TryPatchType(MapState)", () => TryPatchType(harmony, "TaleWorlds.CampaignSystem.GameState.MapState", new[] { "OnTick", "OnMapModeTick", "OnFrameTick" }));


### PR DESCRIPTION
## Summary
- expose the hard pause skip and visual skipping toggles through MapPerfConfig using MCM-backed getters
- gate the pause skipper visual prefix behind the new SkipPausedVisuals flag
- add matching MCM settings so HardPauseSkip and SkipPausedVisuals can be changed at runtime

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e0545d49008320888d84be8808e705