### PR TITLE
fix: derive pause skipper harmony id at runtime

### DIFF
--- a/MapPerfFix/MapPauseSkipper.cs
+++ b/MapPerfFix/MapPauseSkipper.cs
@@ -10,7 +10,7 @@ namespace MapPerfProbe
 {
     internal static class MapPauseSkipper
     {
-        private const string HarmonyId = SubModule.HarmonyId + ".pause-skipper";
+        private static readonly string HarmonyId = SubModule.HarmonyId + ".pause-skipper";
         private static readonly ConcurrentDictionary<(Type Type, string Name), MemberInfo> _boolCache = new();
         private static Harmony _harmony;
 


### PR DESCRIPTION
## Summary
- make the pause skipper Harmony id runtime-initialized rather than const so it can compose with SubModule.HarmonyId
- resolve the CS0133 compile error when building MapPauseSkipper

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e0606dacb48320a67c1a3f5094d880