### PR TITLE
feat: throttle campaign ticks during pause

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -34,8 +34,12 @@ namespace MapPerfProbe
 
         internal static bool Enabled => Get(s => s.Enabled, true);
         internal static bool DebugLogging => Get(s => s.DebugLogging, false);
-        internal static bool HardPauseSkip      => Get(s => s.HardPauseSkip, true);
+        internal static bool HardPauseSkip      => Get(s => s.HardPauseSkip, false);
         internal static bool SkipPausedVisuals  => Get(s => s.SkipPausedVisuals, true);
+        internal static bool SkipCampaignRealTickWhenPaused => Get(s => s.SkipCampaignRealTickWhenPaused, true);
+        internal static bool ThrottleCacheWhenPaused        => Get(s => s.ThrottleCacheWhenPaused, true);
+        internal static bool SkipCacheRealTickWhenPaused    => Get(s => s.SkipCacheRealTickWhenPaused, false);
+        internal static int  CachePauseMinIntervalMs        => ClampInt(Get(s => s.CachePauseMinIntervalMs, 500), 50, 5000);
         internal static bool EnableMapThrottle => Get(s => s.EnableMapThrottle, true);
         internal static bool ThrottleOnlyInFastTime => Get(s => s.ThrottleOnlyInFastTime, true);
         internal static bool DesyncSimWhileThrottling => Get(s => s.DesyncSimWhileThrottling, true);

--- a/MapPerfFix/MapPerfFix.csproj
+++ b/MapPerfFix/MapPerfFix.csproj
@@ -97,6 +97,7 @@
     <Compile Include="MapIdleDrainProbe.cs" />
     <Compile Include="MapIdleDrainMitigator.cs" />
     <Compile Include="MapPauseSkipper.cs" />
+    <Compile Include="PauseSimSkipper.cs" />
     <Compile Include="MapPerfLog.cs" />
     <Compile Include="PeriodicHubDeferrer.cs" />
     <Compile Include="MapPerfSettings.cs" />

--- a/MapPerfFix/MapPerfSettings.cs
+++ b/MapPerfFix/MapPerfSettings.cs
@@ -79,13 +79,32 @@ namespace MapPerfProbe
         [SettingPropertyBool("Hard-skip MapScreen while paused",
             HintText = "Skips MapScreen.OnFrameTick when time is stopped.",
             RequireRestart = false, Order = 0)]
-        public bool HardPauseSkip { get; set; } = true;
+        public bool HardPauseSkip { get; set; } = false;
 
         [SettingPropertyGroup("Map Performance/Pause", GroupOrder = 2)]
         [SettingPropertyBool("Skip party/army visuals while paused",
             HintText = "Stops PartyVisual/ArmyVisual Tick except hovered/selected/tracked and on-screen.",
             RequireRestart = false, Order = 1)]
         public bool SkipPausedVisuals { get; set; } = true;
+
+        [SettingPropertyGroup("Map Performance/Pause", GroupOrder = 2)]
+        [SettingPropertyBool("Skip Campaign.RealTick while paused",
+            HintText = "Verhindert Kampagnen-Sim im Pausenmodus.", RequireRestart = false, Order = 2)]
+        public bool SkipCampaignRealTickWhenPaused { get; set; } = true;
+
+        [SettingPropertyGroup("Map Performance/Pause", GroupOrder = 2)]
+        [SettingPropertyBool("Throttle Cache RealTick while paused",
+            HintText = "Drosselt CampaignTickCacheDataStore.RealTick bei Pause.", RequireRestart = false, Order = 3)]
+        public bool ThrottleCacheWhenPaused { get; set; } = true;
+
+        [SettingPropertyGroup("Map Performance/Pause", GroupOrder = 2)]
+        [SettingPropertyBool("Skip Cache RealTick entirely while paused",
+            HintText = "Überspringt Cache-Updates komplett bei Pause.", RequireRestart = false, Order = 4)]
+        public bool SkipCacheRealTickWhenPaused { get; set; } = false;
+
+        [SettingPropertyGroup("Map Performance/Pause", GroupOrder = 2)]
+        [SettingPropertyInteger("Cache throttle period (ms)", 50, 5000, RequireRestart = false, Order = 5)]
+        public int CachePauseMinIntervalMs { get; set; } = 500;
 
         // -------- Message dedup ----------
         [SettingPropertyGroup("Message Filters", GroupOrder = 10)]

--- a/MapPerfFix/PauseSimSkipper.cs
+++ b/MapPerfFix/PauseSimSkipper.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+
+namespace MapPerfProbe
+{
+    internal static class PauseSimSkipper
+    {
+        private const string HarmonyId = "MapPerfProbe.pause-sim-skipper";
+        private static Harmony _harmony;
+        private static long _lastCacheTicks;
+        private static readonly double TicksToMs = 1000.0 / Stopwatch.Frequency;
+
+        internal static void Install()
+        {
+            if (_harmony != null) return;
+            try
+            {
+                _harmony = new Harmony(HarmonyId);
+            }
+            catch (Exception ex)
+            {
+                MapPerfLog.Warn($"PauseSimSkipper Harmony init failed: {ex.Message}");
+                _harmony = null;
+                return;
+            }
+
+            TryPatchCampaignRealTick();
+            TryPatchCacheRealTick();
+        }
+
+        private static void TryPatchCampaignRealTick()
+        {
+            if (_harmony == null) return;
+            try
+            {
+                var method = AccessTools.Method(typeof(Campaign), "RealTick", new[] { typeof(float) });
+                if (!IsPatchable(method)) return;
+
+                _harmony.Patch(method, prefix: new HarmonyMethod(typeof(PauseSimSkipper), nameof(Campaign_RealTick_Prefix)));
+            }
+            catch (Exception ex)
+            {
+                MapPerfLog.Warn($"PauseSimSkipper Campaign.RealTick patch failed: {ex.Message}");
+            }
+        }
+
+        private static void TryPatchCacheRealTick()
+        {
+            if (_harmony == null) return;
+            try
+            {
+                var cacheType = AccessTools.TypeByName("TaleWorlds.CampaignSystem.CampaignTickCacheDataStore");
+                if (cacheType == null) return;
+
+                var method = AccessTools.Method(cacheType, "RealTick", new[] { typeof(float) });
+                if (!IsPatchable(method)) return;
+
+                _harmony.Patch(method, prefix: new HarmonyMethod(typeof(PauseSimSkipper), nameof(Cache_RealTick_Prefix)));
+            }
+            catch (Exception ex)
+            {
+                MapPerfLog.Warn($"PauseSimSkipper Cache.RealTick patch failed: {ex.Message}");
+            }
+        }
+
+        private static bool IsPatchable(MethodInfo method)
+        {
+            if (method == null) return false;
+            if (method.IsAbstract) return false;
+            if (method.ContainsGenericParameters) return false;
+            if (method.IsSpecialName) return false;
+            return method.GetMethodBody() != null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsPaused()
+        {
+            var campaign = Campaign.Current;
+            return campaign != null && campaign.TimeControlMode == CampaignTimeControlMode.Stop;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool Campaign_RealTick_Prefix()
+            => !(MapPerfConfig.SkipCampaignRealTickWhenPaused && IsPaused());
+
+        private static bool Cache_RealTick_Prefix(ref float dt)
+        {
+            if (!IsPaused()) return true;
+            if (!MapPerfConfig.ThrottleCacheWhenPaused) return true;
+
+            if (MapPerfConfig.SkipCacheRealTickWhenPaused)
+                return false;
+
+            var now = Stopwatch.GetTimestamp();
+            var msSince = (now - _lastCacheTicks) * TicksToMs;
+            if (msSince < MapPerfConfig.CachePauseMinIntervalMs)
+                return false;
+
+            _lastCacheTicks = now;
+            return true;
+        }
+    }
+}

--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -425,6 +425,7 @@ namespace MapPerfProbe
                 // before broader instrumentation so its bool-prefix can skip the original when needed.
                 SafePatch("PatchMapScreenThrottle", () => PatchMapScreenThrottle(harmony));
                 SafePatch("Install MapPauseSkipper", MapPauseSkipper.Install);
+                SafePatch("Install PauseSimSkipper", PauseSimSkipper.Install);
 
                 // High-level map/UI hooks (already working)
                 SafePatch("TryPatchType(MapState)", () => TryPatchType(harmony, "TaleWorlds.CampaignSystem.GameState.MapState", new[] { "OnTick", "OnMapModeTick", "OnFrameTick" }));


### PR DESCRIPTION
## Summary
- add a PauseSimSkipper Harmony installer to skip or throttle Campaign.RealTick when paused
- expose MCM toggles for pausing campaign and cache ticks with configurable interval defaults
- register the new skipper during SubModule bootstrapping and include it in the project file

## Testing
- `dotnet build MapPerfFix.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0775130cc8320a2dda62d294938a9