### PR TITLE
fix: resolve init wiring delegate signature

### DIFF
--- a/MapPerfFix/InitGate.cs
+++ b/MapPerfFix/InitGate.cs
@@ -26,7 +26,7 @@ namespace MapPerfProbe
             try { CampaignEvents.OnNewGameCreatedEvent.AddNonSerializedListener(NewGameOwner, _ => OnReady()); }
             catch { /* best effort */ }
 
-            try { CampaignEvents.OnSessionLaunchedEvent.AddNonSerializedListener(SessionOwner, OnReady); }
+            try { CampaignEvents.OnSessionLaunchedEvent.AddNonSerializedListener(SessionOwner, _ => OnReady()); }
             catch { /* best effort */ }
         }
 

--- a/MapPerfFix/MapPauseSkipper.cs
+++ b/MapPerfFix/MapPauseSkipper.cs
@@ -155,21 +155,21 @@ namespace MapPerfProbe
             var key = (Type: type, Name: name);
             var member = _boolCache.GetOrAdd(key, k =>
             {
-                var fi = AccessTools.Field(k.Type, k.Name);
-                if (fi != null && fi.FieldType == typeof(bool)) return (MemberInfo)fi;
+                var fieldLookup = AccessTools.Field(k.Type, k.Name);
+                if (fieldLookup != null && fieldLookup.FieldType == typeof(bool)) return (MemberInfo)fieldLookup;
 
-                var pi = AccessTools.Property(k.Type, k.Name);
-                if (pi != null && pi.PropertyType == typeof(bool)) return (MemberInfo)pi;
+                var propertyLookup = AccessTools.Property(k.Type, k.Name);
+                if (propertyLookup != null && propertyLookup.PropertyType == typeof(bool)) return (MemberInfo)propertyLookup;
 
                 return null;
             });
 
-            var fi = member as FieldInfo;
-            if (fi != null)
+            var fieldInfo = member as FieldInfo;
+            if (fieldInfo != null)
             {
                 try
                 {
-                    return (bool)fi.GetValue(instance);
+                    return (bool)fieldInfo.GetValue(instance);
                 }
                 catch
                 {
@@ -177,12 +177,12 @@ namespace MapPerfProbe
                 }
             }
 
-            var pi = member as PropertyInfo;
-            if (pi != null)
+            var propertyInfo = member as PropertyInfo;
+            if (propertyInfo != null)
             {
                 try
                 {
-                    var getter = pi.GetMethod;
+                    var getter = propertyInfo.GetMethod;
                     return getter != null ? (bool)getter.Invoke(instance, Array.Empty<object>()) : (bool?)null;
                 }
                 catch


### PR DESCRIPTION
## Summary
- wrap the session launched listener in a lambda so it matches the expected Action signature
- rename cached bool lookup locals to avoid inner-scope shadowing of outer variables

## Testing
- dotnet build *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e089efb2688320b318b828f11a0700