### PR TITLE
Restore real map optimization and observable diagnostics

### DIFF
--- a/MapPerfFix/MapPerfConfig.cs
+++ b/MapPerfFix/MapPerfConfig.cs
@@ -15,23 +15,25 @@ namespace MapPerfProbe
             }
             catch
             {
-                // Settings may be unavailable during early module startup; use safe defaults.
             }
 
             return fallback;
         }
 
         internal static bool Enabled => Get(s => s.Enabled, true);
-        internal static bool DebugLogging => Get(s => s.DebugLogging, false);
+        internal static bool DebugLogging => Get(s => s.DebugLogging, true);
+        internal static bool OptimizeHiddenPartyVisuals =>
+            Get(s => s.OptimizeHiddenPartyVisuals, true);
         internal static bool TuneGcLatency => Get(s => s.TuneGcLatency, true);
-        internal static bool OptimizePausedOffscreenVisuals =>
-            Get(s => s.OptimizePausedOffscreenVisuals, true);
-
-        internal static int PausedVisualTickCadence =>
-            Clamp(Get(s => s.PausedVisualTickCadence, 4), 2, 12);
+        internal static bool ProfileTorCampaignCallbacks =>
+            Get(s => s.ProfileTorCampaignCallbacks, true);
+        internal static int SlowCallbackThresholdMs =>
+            Clamp(Get(s => s.SlowCallbackThresholdMs, 8), 1, 100);
+        internal static int ProfilerReportIntervalSeconds =>
+            Clamp(Get(s => s.ProfilerReportIntervalSeconds, 30), 5, 120);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int Clamp(int value, int min, int max)
-            => value < min ? min : (value > max ? max : value);
+        private static int Clamp(int value, int minimum, int maximum) =>
+            value < minimum ? minimum : (value > maximum ? maximum : value);
     }
 }

--- a/MapPerfFix/MapPerfLog.cs
+++ b/MapPerfFix/MapPerfLog.cs
@@ -11,15 +11,31 @@ namespace MapPerfProbe
     {
         private const long MaxBytes = 5L * 1024 * 1024;
         private const int MaxBackups = 3;
+        private const long PathRetryCooldownTicks = TimeSpan.TicksPerSecond * 5L;
+
         private static readonly object Sync = new object();
         private static readonly string[] CandidatePaths = BuildCandidatePaths();
         private static string _path;
+        private static long _activePathSize;
+        private static long _nextPathRetryUtcTicks;
         private static int _debugEnabled;
         private static int _initialized;
         private static MethodInfo _enginePrint;
+        private static ParameterInfo[] _enginePrintParameters;
         private static int _enginePrintResolved;
 
-        internal static string CurrentPath => _path ?? CandidatePaths[0];
+        internal static string CurrentPath
+        {
+            get
+            {
+                var selected = _path;
+                if (!string.IsNullOrEmpty(selected))
+                    return selected;
+                return CandidatePaths.Length > 0
+                    ? CandidatePaths[0]
+                    : "<filesystem logging unavailable>";
+            }
+        }
 
         internal static bool DebugEnabled
         {
@@ -39,6 +55,9 @@ namespace MapPerfProbe
                     if (TrySelectPath(CandidatePaths[i]))
                         break;
                 }
+
+                if (string.IsNullOrEmpty(_path))
+                    _nextPathRetryUtcTicks = DateTime.UtcNow.Ticks + PathRetryCooldownTicks;
             }
 
             Info("Logger initialized. File: " + CurrentPath);
@@ -69,21 +88,32 @@ namespace MapPerfProbe
             var written = false;
             lock (Sync)
             {
-                if (!string.IsNullOrEmpty(_path))
-                    written = TryAppend(_path, line);
-
-                if (!written)
+                var now = DateTime.UtcNow.Ticks;
+                if (now >= _nextPathRetryUtcTicks)
                 {
-                    for (var i = 0; i < CandidatePaths.Length; i++)
-                    {
-                        if (string.Equals(CandidatePaths[i], _path, StringComparison.OrdinalIgnoreCase))
-                            continue;
-                        if (!TrySelectPath(CandidatePaths[i]))
-                            continue;
+                    if (!string.IsNullOrEmpty(_path))
                         written = TryAppend(_path, line);
-                        if (written)
-                            break;
+
+                    if (!written)
+                    {
+                        for (var i = 0; i < CandidatePaths.Length; i++)
+                        {
+                            if (string.Equals(
+                                CandidatePaths[i],
+                                _path,
+                                StringComparison.OrdinalIgnoreCase))
+                                continue;
+                            if (!TrySelectPath(CandidatePaths[i]))
+                                continue;
+                            written = TryAppend(_path, line);
+                            if (written)
+                                break;
+                        }
                     }
+
+                    _nextPathRetryUtcTicks = written
+                        ? 0L
+                        : now + PathRetryCooldownTicks;
                 }
             }
 
@@ -103,11 +133,17 @@ namespace MapPerfProbe
                 if (!string.IsNullOrEmpty(directory))
                     Directory.CreateDirectory(directory);
 
-                using (var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+                using (var stream = new FileStream(
+                    path,
+                    FileMode.Append,
+                    FileAccess.Write,
+                    FileShare.ReadWrite))
                 {
                 }
 
+                var info = new FileInfo(path);
                 _path = path;
+                _activePathSize = info.Exists ? info.Length : 0L;
                 RotateIfNeeded(path);
                 return true;
             }
@@ -121,10 +157,19 @@ namespace MapPerfProbe
         {
             try
             {
-                RotateIfNeeded(path);
                 var bytes = Encoding.UTF8.GetBytes(line + Environment.NewLine);
-                using (var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+                RotateIfNeeded(path);
+                using (var stream = new FileStream(
+                    path,
+                    FileMode.Append,
+                    FileAccess.Write,
+                    FileShare.ReadWrite))
+                {
                     stream.Write(bytes, 0, bytes.Length);
+                }
+
+                if (string.Equals(path, _path, StringComparison.OrdinalIgnoreCase))
+                    _activePathSize += bytes.Length;
                 return true;
             }
             catch
@@ -135,11 +180,17 @@ namespace MapPerfProbe
 
         private static void RotateIfNeeded(string path)
         {
+            if (!string.Equals(path, _path, StringComparison.OrdinalIgnoreCase) ||
+                _activePathSize < MaxBytes)
+                return;
+
             try
             {
-                var info = new FileInfo(path);
-                if (!info.Exists || info.Length < MaxBytes)
+                if (!File.Exists(path))
+                {
+                    _activePathSize = 0L;
                     return;
+                }
 
                 for (var index = MaxBackups - 1; index >= 1; index--)
                 {
@@ -155,6 +206,7 @@ namespace MapPerfProbe
                 if (File.Exists(first))
                     File.Delete(first);
                 File.Move(path, first);
+                _activePathSize = 0L;
             }
             catch
             {
@@ -163,16 +215,30 @@ namespace MapPerfProbe
 
         private static string[] BuildCandidatePaths()
         {
-            var paths = new List<string>();
-            AddCandidate(paths, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
-            AddCandidate(paths, Environment.GetFolderPath(Environment.SpecialFolder.Personal));
+            try
+            {
+                var paths = new List<string>();
+                AddCandidate(
+                    paths,
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+                AddCandidate(
+                    paths,
+                    Environment.GetFolderPath(Environment.SpecialFolder.Personal));
 
-            var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            if (!string.IsNullOrEmpty(local))
-                paths.Add(Path.Combine(local, "MapPerfProbe", "probe.log"));
+                var local = Environment.GetFolderPath(
+                    Environment.SpecialFolder.LocalApplicationData);
+                if (!string.IsNullOrEmpty(local))
+                    paths.Add(Path.Combine(local, "MapPerfProbe", "probe.log"));
 
-            paths.Add(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MapPerfProbe.log"));
-            return paths.ToArray();
+                paths.Add(Path.Combine(
+                    AppDomain.CurrentDomain.BaseDirectory,
+                    "MapPerfProbe.log"));
+                return paths.ToArray();
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
         }
 
         private static void AddCandidate(ICollection<string> paths, string documents)
@@ -207,10 +273,10 @@ namespace MapPerfProbe
                 }
 
                 var method = _enginePrint;
-                if (method == null)
+                var parameters = _enginePrintParameters;
+                if (method == null || parameters == null)
                     return;
 
-                var parameters = method.GetParameters();
                 var arguments = new object[parameters.Length];
                 arguments[0] = line;
                 for (var i = 1; i < parameters.Length; i++)
@@ -233,25 +299,37 @@ namespace MapPerfProbe
 
         private static void ResolveEnginePrint()
         {
-            var debugType = Type.GetType("TaleWorlds.Library.Debug, TaleWorlds.Library", false);
+            var debugType = Type.GetType(
+                "TaleWorlds.Library.Debug, TaleWorlds.Library",
+                false);
             if (debugType == null)
+            {
+                _enginePrint = null;
+                _enginePrintParameters = null;
                 return;
+            }
 
             MethodInfo best = null;
+            ParameterInfo[] bestParameters = null;
             var methods = debugType.GetMethods(BindingFlags.Public | BindingFlags.Static);
             for (var i = 0; i < methods.Length; i++)
             {
                 var method = methods[i];
                 if (!string.Equals(method.Name, "Print", StringComparison.Ordinal))
                     continue;
+
                 var parameters = method.GetParameters();
                 if (parameters.Length == 0 || parameters[0].ParameterType != typeof(string))
                     continue;
-                if (best == null || parameters.Length < best.GetParameters().Length)
-                    best = method;
+                if (bestParameters != null && parameters.Length >= bestParameters.Length)
+                    continue;
+
+                best = method;
+                bestParameters = parameters;
             }
 
             _enginePrint = best;
+            _enginePrintParameters = bestParameters;
         }
     }
 }

--- a/MapPerfFix/MapPerfLog.cs
+++ b/MapPerfFix/MapPerfLog.cs
@@ -1,82 +1,257 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Text;
 using System.Threading;
 
 namespace MapPerfProbe
 {
     internal static class MapPerfLog
     {
-        private static readonly string DefaultPath =
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                         "Mount and Blade II Bannerlord", "Logs", "MapPerfProbe", "probe.log");
-
-        private static readonly object _sync = new object();
         private const long MaxBytes = 5L * 1024 * 1024;
         private const int MaxBackups = 3;
-        private static string _path = DefaultPath;
+        private static readonly object Sync = new object();
+        private static readonly string[] CandidatePaths = BuildCandidatePaths();
+        private static string _path;
         private static int _debugEnabled;
+        private static int _initialized;
+        private static MethodInfo _enginePrint;
+        private static int _enginePrintResolved;
 
-        static MapPerfLog()
-        {
-            try { EnsureDir(); RotateIfNeeded(); } catch { }
-        }
+        internal static string CurrentPath => _path ?? CandidatePaths[0];
 
-        public static bool DebugEnabled
+        internal static bool DebugEnabled
         {
             get => Volatile.Read(ref _debugEnabled) != 0;
             set => Interlocked.Exchange(ref _debugEnabled, value ? 1 : 0);
         }
 
-        public static void Debug(string msg)
+        internal static void Initialize()
         {
-            if (!DebugEnabled) return;
-            Write("DEBUG", msg, null);
+            if (Interlocked.Exchange(ref _initialized, 1) != 0)
+                return;
+
+            lock (Sync)
+            {
+                for (var i = 0; i < CandidatePaths.Length; i++)
+                {
+                    if (TrySelectPath(CandidatePaths[i]))
+                        break;
+                }
+            }
+
+            Info("Logger initialized. File: " + CurrentPath);
         }
 
-        public static void Info(string msg) => Write("INFO", msg, null);
-        public static void Warn(string msg) => Write("WARN", msg, null);
-        public static void Error(string msg, Exception ex = null) => Write("ERROR", msg, ex);
-
-        private static void Write(string level, string msg, Exception ex)
+        internal static void Debug(string message)
         {
-            lock (_sync)
+            if (DebugEnabled)
+                Write("DEBUG", message, null);
+        }
+
+        internal static void Info(string message) => Write("INFO", message, null);
+        internal static void Warn(string message) => Write("WARN", message, null);
+        internal static void Error(string message, Exception exception = null) =>
+            Write("ERROR", message, exception);
+
+        private static void Write(string level, string message, Exception exception)
+        {
+            if (Volatile.Read(ref _initialized) == 0)
+                Initialize();
+
+            var line = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff") +
+                       " [" + level + "] " + message;
+            if (exception != null)
+                line += " :: " + exception.GetType().FullName + ": " + exception.Message +
+                        Environment.NewLine + exception.StackTrace;
+
+            var written = false;
+            lock (Sync)
             {
-                try
+                if (!string.IsNullOrEmpty(_path))
+                    written = TryAppend(_path, line);
+
+                if (!written)
                 {
-                    EnsureDir(); RotateIfNeeded();
-                    var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} [{level}] {msg}";
-                    if (ex != null) line += $" :: {ex.GetType().Name}: {ex.Message}";
-                    File.AppendAllText(_path, line + Environment.NewLine);
+                    for (var i = 0; i < CandidatePaths.Length; i++)
+                    {
+                        if (string.Equals(CandidatePaths[i], _path, StringComparison.OrdinalIgnoreCase))
+                            continue;
+                        if (!TrySelectPath(CandidatePaths[i]))
+                            continue;
+                        written = TryAppend(_path, line);
+                        if (written)
+                            break;
+                    }
                 }
+            }
+
+            TryMirrorToEngine("[MapPerfProbe] " + line);
+            if (!written)
+            {
+                try { Console.Error.WriteLine("[MapPerfProbe] " + line); }
                 catch { }
             }
         }
 
-        private static void EnsureDir()
-        {
-            var dir = Path.GetDirectoryName(_path);
-            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-        }
-
-        private static void RotateIfNeeded()
+        private static bool TrySelectPath(string path)
         {
             try
             {
-                var fi = new FileInfo(_path);
-                if (!fi.Exists || fi.Length < MaxBytes) return;
+                var directory = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(directory))
+                    Directory.CreateDirectory(directory);
 
-                for (int i = MaxBackups - 1; i >= 1; i--)
+                using (var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
                 {
-                    var src = _path + "." + i;
-                    var dst = _path + "." + (i + 1);
-                    if (File.Exists(dst)) File.Delete(dst);
-                    if (File.Exists(src)) File.Move(src, dst);
                 }
-                var first = _path + ".1";
-                if (File.Exists(first)) File.Delete(first);
-                File.Move(_path, first);
+
+                _path = path;
+                RotateIfNeeded(path);
+                return true;
             }
-            catch { }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static bool TryAppend(string path, string line)
+        {
+            try
+            {
+                RotateIfNeeded(path);
+                var bytes = Encoding.UTF8.GetBytes(line + Environment.NewLine);
+                using (var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+                    stream.Write(bytes, 0, bytes.Length);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void RotateIfNeeded(string path)
+        {
+            try
+            {
+                var info = new FileInfo(path);
+                if (!info.Exists || info.Length < MaxBytes)
+                    return;
+
+                for (var index = MaxBackups - 1; index >= 1; index--)
+                {
+                    var source = path + "." + index;
+                    var destination = path + "." + (index + 1);
+                    if (File.Exists(destination))
+                        File.Delete(destination);
+                    if (File.Exists(source))
+                        File.Move(source, destination);
+                }
+
+                var first = path + ".1";
+                if (File.Exists(first))
+                    File.Delete(first);
+                File.Move(path, first);
+            }
+            catch
+            {
+            }
+        }
+
+        private static string[] BuildCandidatePaths()
+        {
+            var paths = new List<string>();
+            AddCandidate(paths, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+            AddCandidate(paths, Environment.GetFolderPath(Environment.SpecialFolder.Personal));
+
+            var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!string.IsNullOrEmpty(local))
+                paths.Add(Path.Combine(local, "MapPerfProbe", "probe.log"));
+
+            paths.Add(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MapPerfProbe.log"));
+            return paths.ToArray();
+        }
+
+        private static void AddCandidate(ICollection<string> paths, string documents)
+        {
+            if (string.IsNullOrEmpty(documents))
+                return;
+
+            var candidate = Path.Combine(
+                documents,
+                "Mount and Blade II Bannerlord",
+                "Logs",
+                "MapPerfProbe",
+                "probe.log");
+
+            foreach (var existing in paths)
+            {
+                if (string.Equals(existing, candidate, StringComparison.OrdinalIgnoreCase))
+                    return;
+            }
+
+            paths.Add(candidate);
+        }
+
+        private static void TryMirrorToEngine(string line)
+        {
+            try
+            {
+                if (Volatile.Read(ref _enginePrintResolved) == 0)
+                {
+                    ResolveEnginePrint();
+                    Volatile.Write(ref _enginePrintResolved, 1);
+                }
+
+                var method = _enginePrint;
+                if (method == null)
+                    return;
+
+                var parameters = method.GetParameters();
+                var arguments = new object[parameters.Length];
+                arguments[0] = line;
+                for (var i = 1; i < parameters.Length; i++)
+                {
+                    var parameter = parameters[i];
+                    if (parameter.HasDefaultValue)
+                        arguments[i] = parameter.DefaultValue;
+                    else if (parameter.ParameterType.IsValueType)
+                        arguments[i] = Activator.CreateInstance(parameter.ParameterType);
+                    else
+                        arguments[i] = null;
+                }
+
+                method.Invoke(null, arguments);
+            }
+            catch
+            {
+            }
+        }
+
+        private static void ResolveEnginePrint()
+        {
+            var debugType = Type.GetType("TaleWorlds.Library.Debug, TaleWorlds.Library", false);
+            if (debugType == null)
+                return;
+
+            MethodInfo best = null;
+            var methods = debugType.GetMethods(BindingFlags.Public | BindingFlags.Static);
+            for (var i = 0; i < methods.Length; i++)
+            {
+                var method = methods[i];
+                if (!string.Equals(method.Name, "Print", StringComparison.Ordinal))
+                    continue;
+                var parameters = method.GetParameters();
+                if (parameters.Length == 0 || parameters[0].ParameterType != typeof(string))
+                    continue;
+                if (best == null || parameters.Length < best.GetParameters().Length)
+                    best = method;
+            }
+
+            _enginePrint = best;
         }
     }
 }

--- a/MapPerfFix/MapPerfSettings.cs
+++ b/MapPerfFix/MapPerfSettings.cs
@@ -6,36 +6,47 @@ namespace MapPerfProbe
 {
     public sealed class MapPerfSettings : AttributeGlobalSettings<MapPerfSettings>
     {
-        // Keep the existing ID so old configurations migrate. Removed unsafe fields are ignored.
         public override string Id => "MapPerfProbe_v1";
-        public override string DisplayName => "Map Performance Fix";
+        public override string DisplayName => "MapPerfProbe";
         public override string FolderName => "MapPerfProbe";
         public override string FormatType => "json";
 
         [SettingPropertyGroup("General", GroupOrder = 0)]
-        [SettingPropertyBool("Enable Map Performance Fix", RequireRestart = false, Order = 0)]
+        [SettingPropertyBool("Enable MapPerfProbe", RequireRestart = false, Order = 0)]
         public bool Enabled { get; set; } = true;
 
         [SettingPropertyGroup("General", GroupOrder = 0)]
         [SettingPropertyBool("Debug logging", RequireRestart = false, Order = 1)]
-        public bool DebugLogging { get; set; } = false;
+        public bool DebugLogging { get; set; } = true;
+
+        [SettingPropertyGroup("Safe optimizations", GroupOrder = 1)]
+        [SettingPropertyBool("Skip fully hidden mobile-party visual ticks",
+            HintText = "Bannerlord 1.2.x only. Skips rendering and animation work after a mobile party is fully faded and hidden. Campaign simulation, positions, events, AI, and periodic callbacks are untouched.",
+            RequireRestart = false, Order = 0)]
+        public bool OptimizeHiddenPartyVisuals { get; set; } = true;
 
         [SettingPropertyGroup("Safe optimizations", GroupOrder = 1)]
         [SettingPropertyBool("Tune GC latency on the campaign map",
-            HintText = "Changes only the .NET garbage-collector latency mode. Campaign and UI callbacks are never skipped.",
-            RequireRestart = false, Order = 0)]
+            HintText = "Changes only the .NET garbage-collector latency mode.",
+            RequireRestart = false, Order = 1)]
         public bool TuneGcLatency { get; set; } = true;
 
-        [SettingPropertyGroup("Safe optimizations", GroupOrder = 1)]
-        [SettingPropertyBool("Reduce off-screen party visual ticks while paused",
-            HintText = "Affects only confirmed off-screen PartyVisual rendering while campaign time is stopped. The optimization disables itself when required visibility-state members cannot be verified.",
-            RequireRestart = false, Order = 1)]
-        public bool OptimizePausedOffscreenVisuals { get; set; } = true;
+        [SettingPropertyGroup("Diagnostics", GroupOrder = 2)]
+        [SettingPropertyBool("Profile TOR campaign callbacks",
+            HintText = "Measures TOR campaign callback time without skipping or delaying calls and writes aggregate reports to probe.log.",
+            RequireRestart = false, Order = 0)]
+        public bool ProfileTorCampaignCallbacks { get; set; } = true;
 
-        [SettingPropertyGroup("Safe optimizations", GroupOrder = 1)]
-        [SettingPropertyInteger("Paused off-screen visual cadence", 2, 12,
-            HintText = "Run confirmed off-screen party visuals once every N rendered frames while paused.",
+        [SettingPropertyGroup("Diagnostics", GroupOrder = 2)]
+        [SettingPropertyInteger("Slow callback threshold (ms)", 1, 100,
+            HintText = "Individual TOR callbacks at or above this duration are logged.",
+            RequireRestart = false, Order = 1)]
+        public int SlowCallbackThresholdMs { get; set; } = 8;
+
+        [SettingPropertyGroup("Diagnostics", GroupOrder = 2)]
+        [SettingPropertyInteger("Profiler report interval (seconds)", 5, 120,
+            HintText = "Interval for aggregate top-callback reports.",
             RequireRestart = false, Order = 2)]
-        public int PausedVisualTickCadence { get; set; } = 4;
+        public int ProfilerReportIntervalSeconds { get; set; } = 30;
     }
 }

--- a/MapPerfFix/Properties/AssemblyInfo.cs
+++ b/MapPerfFix/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("MapPerfProbe")]
-[assembly: AssemblyDescription("Safe campaign-map performance optimizations for Mount & Blade II: Bannerlord")]
+[assembly: AssemblyDescription("Safe campaign-map performance optimization and TOR callback profiling for Mount & Blade II: Bannerlord")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MapPerfProbe")]
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("5279b009-b8c7-44d4-b2ab-d34c7616f3d2")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -1,93 +1,92 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
-using TaleWorlds.InputSystem;
 using TaleWorlds.MountAndBlade;
 
 namespace MapPerfProbe
 {
     /// <summary>
-    /// Safe campaign-map optimizations.
-    ///
-    /// Invariant: never skip, defer, replay, coalesce, or reorder authoritative
-    /// campaign callbacks. Only confirmed rendering-only work may be throttled.
+    /// Campaign-map performance work that preserves the authoritative callback path.
+    /// No campaign, AI, event, periodic, save, or UI callback is skipped or deferred.
     /// </summary>
     public sealed class SubModule : MBSubModuleBase
     {
-        private const string HarmonyId = "mmq.mapperffix.safe";
-        private const int PatchRetryFrames = 120;
-        private const int PatchCompatibilityCheckFrames = 600;
-
-        private static readonly string[] PartyVisualTypeNames =
-        {
-            "SandBox.View.Map.PartyVisual"
-        };
+        private const string HarmonyId = "mmq.mapperfprobe.safe";
+        private const int FirstProbeFrame = 60;
+        private const int ProbeRetryFrames = 120;
+        private const int CompatibilityCheckFrames = 600;
+        private const int MaxProbeAttempts = 10;
 
         private static readonly object PatchSync = new object();
-        private static readonly ConcurrentDictionary<Type, VisualAccessors> AccessorCache =
-            new ConcurrentDictionary<Type, VisualAccessors>();
-        private static readonly Func<Type, VisualAccessors> CreateVisualAccessors =
-            VisualAccessors.Create;
-
         private static Harmony _harmony;
         private static int _frameSequence;
-        private static int _nextPatchProbeFrame = PatchRetryFrames;
-        private static int _nextPatchCompatibilityFrame;
+        private static int _nextProbeFrame = FirstProbeFrame;
+        private static int _nextCompatibilityFrame;
+        private static int _probeAttempts;
+        private static int _configurationEnabled = 1;
+        private static int _hiddenVisualOptimizationEnabled = 1;
+        private static int _visualPrefixEnabled;
         private static bool _visualPatchInstalled;
-        private static int _visualOptimizationEnabled;
+        private static bool _visualProbeCompleted;
         private static MethodInfo _visualTickMethod;
-        private static bool _foreignPatchLogged;
-        private static int _inputSampleFrame = -1;
-        private static bool _inputSampleValue;
-
+        private static HiddenPartyVisualAccessors _hiddenVisualAccessors;
+        private static bool _statusMessageShown;
         private static bool _gcModeCaptured;
         private static bool _gcModeOwned;
         private static bool _gcTuningFailed;
         private static GCLatencyMode _originalGcMode;
         private static GCLatencyMode _appliedGcMode;
+        private static long _visualCalls;
+        private static long _hiddenVisualSkips;
+        private static long _visualFailOpen;
+        private static long _nextVisualReportTimestamp;
 
         protected override void OnSubModuleLoad()
         {
             base.OnSubModuleLoad();
 
             MapPerfLog.DebugEnabled = MapPerfConfig.DebugLogging;
+            MapPerfLog.Initialize();
             CaptureGcMode();
 
             try
             {
                 _harmony = new Harmony(HarmonyId);
+                MapPerfLog.Info("MapPerfProbe 2.1.0 loaded. Authoritative campaign callbacks remain synchronous.");
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                MapPerfLog.Error("Harmony initialization failed", ex);
+                MapPerfLog.Error("Harmony initialization failed", exception);
                 _harmony = null;
             }
-
-            MapPerfLog.Info("=== Map Performance Fix 2.0 started ===");
         }
 
         protected override void OnSubModuleUnloaded()
         {
-            Volatile.Write(ref _visualOptimizationEnabled, 0);
+            Volatile.Write(ref _visualPrefixEnabled, 0);
 
             try
             {
                 if (_harmony != null)
                     _harmony.UnpatchAll(HarmonyId);
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
-                MapPerfLog.Error("Harmony unpatch failed", ex);
+                MapPerfLog.Error("Harmony unpatch failed", exception);
             }
 
             RestoreGcMode();
-            MapPerfLog.Info("=== Map Performance Fix 2.0 stopped ===");
+            TorCallbackProfiler.Reset();
+            MapPerfLog.Info("MapPerfProbe stopped.");
             base.OnSubModuleUnloaded();
         }
 
@@ -102,20 +101,322 @@ namespace MapPerfProbe
                 frame = 1;
             }
 
-            MapPerfLog.DebugEnabled = MapPerfConfig.DebugLogging;
+            RefreshConfiguration();
 
-            if (!_visualPatchInstalled && frame >= Volatile.Read(ref _nextPatchProbeFrame))
+            if (frame >= Volatile.Read(ref _nextProbeFrame) &&
+                (!_visualProbeCompleted || !TorCallbackProfiler.InstallationComplete))
             {
-                Volatile.Write(ref _nextPatchProbeFrame, frame + PatchRetryFrames);
-                TryInstallVisualPatch();
+                Volatile.Write(ref _nextProbeFrame, frame + ProbeRetryFrames);
+                ProbeRuntimeTargets();
             }
-            else if (_visualPatchInstalled && frame >= Volatile.Read(ref _nextPatchCompatibilityFrame))
+
+            if (_visualPatchInstalled && frame >= Volatile.Read(ref _nextCompatibilityFrame))
             {
-                Volatile.Write(ref _nextPatchCompatibilityFrame, frame + PatchCompatibilityCheckFrames);
+                Volatile.Write(ref _nextCompatibilityFrame, frame + CompatibilityCheckFrames);
                 DisableVisualPatchIfCompatibilityChanged();
             }
 
             UpdateGcMode();
+            TorCallbackProfiler.ReportIfDue();
+            ReportVisualStatsIfDue();
+
+            if (!_statusMessageShown && frame >= FirstProbeFrame && IsCampaignMapActive())
+            {
+                _statusMessageShown = true;
+                TryShowStatusMessage();
+            }
+        }
+
+        private static void RefreshConfiguration()
+        {
+            MapPerfLog.DebugEnabled = MapPerfConfig.DebugLogging;
+            Volatile.Write(ref _configurationEnabled, MapPerfConfig.Enabled ? 1 : 0);
+            Volatile.Write(
+                ref _hiddenVisualOptimizationEnabled,
+                MapPerfConfig.OptimizeHiddenPartyVisuals ? 1 : 0);
+
+            TorCallbackProfiler.Configure(
+                MapPerfConfig.Enabled && MapPerfConfig.ProfileTorCampaignCallbacks,
+                MapPerfConfig.SlowCallbackThresholdMs,
+                MapPerfConfig.ProfilerReportIntervalSeconds);
+        }
+
+        private static void ProbeRuntimeTargets()
+        {
+            if (_harmony == null)
+                return;
+
+            lock (PatchSync)
+            {
+                if (!_visualProbeCompleted)
+                    TryInstallHiddenPartyVisualPatch();
+
+                if (!TorCallbackProfiler.InstallationComplete)
+                    TorCallbackProfiler.TryInstall(_harmony);
+
+                _probeAttempts++;
+                if (_probeAttempts >= MaxProbeAttempts && !_visualProbeCompleted)
+                {
+                    _visualProbeCompleted = true;
+                    MapPerfLog.Warn(
+                        "No supported legacy SandBox.View.Map.PartyVisual tick was found after " +
+                        MaxProbeAttempts + " probes. Hidden-party visual optimization is inactive.");
+                }
+            }
+        }
+
+        private static void TryInstallHiddenPartyVisualPatch()
+        {
+            var legacyType = AccessTools.TypeByName("SandBox.View.Map.PartyVisual");
+            if (legacyType == null)
+            {
+                var modernType = AccessTools.TypeByName(
+                    "SandBox.View.Map.Visuals.MobilePartyVisual");
+                if (modernType != null)
+                {
+                    _visualProbeCompleted = true;
+                    MapPerfLog.Info(
+                        "Detected the modern MobilePartyVisual implementation. Bannerlord already gates " +
+                        "hidden AgentVisuals in this code path; no redundant visual skip was installed.");
+                }
+                else
+                {
+                    MapPerfLog.Debug("SandBox party visual types are not loaded yet.");
+                }
+                return;
+            }
+
+            var method = FindLegacyPartyVisualTick(legacyType);
+            if (method == null)
+            {
+                _visualProbeCompleted = true;
+                MapPerfLog.Warn(
+                    "Legacy PartyVisual was found, but its Tick signature is unsupported. " +
+                    "The visual optimization was not installed.");
+                return;
+            }
+
+            var accessors = HiddenPartyVisualAccessors.Create(legacyType);
+            if (!accessors.IsSupported)
+            {
+                _visualProbeCompleted = true;
+                MapPerfLog.Warn(
+                    "Legacy PartyVisual optimization is unavailable: " + accessors.UnsupportedReason);
+                return;
+            }
+
+            if (HasForeignPatches(method, out var owners))
+            {
+                _visualProbeCompleted = true;
+                MapPerfLog.Warn(
+                    "PartyVisual.Tick is already patched by: " + owners +
+                    ". The hidden-party optimization was not installed.");
+                return;
+            }
+
+            try
+            {
+                var prefixMethod = typeof(SubModule).GetMethod(
+                    nameof(HiddenPartyVisualPrefix),
+                    BindingFlags.Public | BindingFlags.Static);
+                if (prefixMethod == null)
+                    throw new MissingMethodException(nameof(HiddenPartyVisualPrefix));
+
+                _harmony.Patch(method, prefix: new HarmonyMethod(prefixMethod));
+                _hiddenVisualAccessors = accessors;
+                _visualTickMethod = method;
+                _visualPatchInstalled = true;
+                _visualProbeCompleted = true;
+                Volatile.Write(ref _visualPrefixEnabled, 1);
+                _nextCompatibilityFrame =
+                    Volatile.Read(ref _frameSequence) + CompatibilityCheckFrames;
+                _nextVisualReportTimestamp =
+                    Stopwatch.GetTimestamp() + Stopwatch.Frequency * 30L;
+
+                MapPerfLog.Info(
+                    "Installed legacy hidden mobile-party visual optimization on " +
+                    DescribeMethod(method) + ". Fully hidden parties resume immediately when visible.");
+            }
+            catch (Exception exception)
+            {
+                Volatile.Write(ref _visualPrefixEnabled, 0);
+                _visualProbeCompleted = true;
+                MapPerfLog.Error("PartyVisual.Tick patch failed", exception);
+            }
+        }
+
+        private static MethodInfo FindLegacyPartyVisualTick(Type type)
+        {
+            MethodInfo singleFloatFallback = null;
+            var methods = type.GetMethods(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.DeclaredOnly);
+
+            for (var index = 0; index < methods.Length; index++)
+            {
+                var method = methods[index];
+                if (!string.Equals(method.Name, "Tick", StringComparison.Ordinal) ||
+                    method.IsStatic || method.IsAbstract || method.ContainsGenericParameters ||
+                    method.ReturnType != typeof(void) || method.GetMethodBody() == null)
+                    continue;
+
+                var parameters = method.GetParameters();
+                if (parameters.Length == 3 &&
+                    parameters[0].ParameterType == typeof(float) &&
+                    parameters[1].ParameterType == typeof(int).MakeByRefType())
+                {
+                    var arrayByRef = parameters[2].ParameterType;
+                    var arrayType = arrayByRef.IsByRef ? arrayByRef.GetElementType() : null;
+                    if (arrayType != null && arrayType.IsArray &&
+                        arrayType.GetElementType() == type)
+                        return method;
+                }
+
+                if (parameters.Length == 1 && parameters[0].ParameterType == typeof(float))
+                    singleFloatFallback = method;
+            }
+
+            return singleFloatFallback;
+        }
+
+        [HarmonyPriority(Priority.Last)]
+        public static bool HiddenPartyVisualPrefix(object __instance)
+        {
+            Interlocked.Increment(ref _visualCalls);
+
+            if (Volatile.Read(ref _visualPrefixEnabled) == 0 ||
+                Volatile.Read(ref _configurationEnabled) == 0 ||
+                Volatile.Read(ref _hiddenVisualOptimizationEnabled) == 0 ||
+                __instance == null)
+                return true;
+
+            try
+            {
+                var accessors = _hiddenVisualAccessors;
+                if (accessors == null || !accessors.ShouldSkip(__instance))
+                    return true;
+
+                Interlocked.Increment(ref _hiddenVisualSkips);
+                return false;
+            }
+            catch
+            {
+                Interlocked.Increment(ref _visualFailOpen);
+                return true;
+            }
+        }
+
+        private static void DisableVisualPatchIfCompatibilityChanged()
+        {
+            var method = _visualTickMethod;
+            if (method == null || _harmony == null)
+                return;
+
+            if (!HasForeignPatches(method, out var owners))
+                return;
+
+            lock (PatchSync)
+            {
+                if (!_visualPatchInstalled || _visualTickMethod == null || _harmony == null)
+                    return;
+
+                Volatile.Write(ref _visualPrefixEnabled, 0);
+                try
+                {
+                    _harmony.Unpatch(_visualTickMethod, HarmonyPatchType.Prefix, HarmonyId);
+                }
+                catch (Exception exception)
+                {
+                    MapPerfLog.Error(
+                        "Could not remove the PartyVisual optimization after a compatibility change",
+                        exception);
+                }
+                finally
+                {
+                    _visualTickMethod = null;
+                    _hiddenVisualAccessors = null;
+                    _visualPatchInstalled = false;
+                }
+
+                MapPerfLog.Warn(
+                    "PartyVisual.Tick gained a foreign patch from " + owners +
+                    "; the visual optimization was disabled and now fails open.");
+            }
+        }
+
+        private static bool HasForeignPatches(MethodBase method, out string owners)
+        {
+            owners = string.Empty;
+            try
+            {
+                var info = Harmony.GetPatchInfo(method);
+                if (info == null)
+                    return false;
+
+                var foreignOwners = new HashSet<string>(StringComparer.Ordinal);
+                CollectForeignOwners(info.Prefixes, foreignOwners);
+                CollectForeignOwners(info.Postfixes, foreignOwners);
+                CollectForeignOwners(info.Transpilers, foreignOwners);
+                CollectForeignOwners(info.Finalizers, foreignOwners);
+                if (foreignOwners.Count == 0)
+                    return false;
+
+                owners = string.Join(", ", foreignOwners.OrderBy(value => value));
+                return true;
+            }
+            catch (Exception exception)
+            {
+                owners = "unknown (patch inspection failed: " + exception.Message + ")";
+                return true;
+            }
+        }
+
+        private static void CollectForeignOwners(
+            IEnumerable<Patch> patches,
+            ISet<string> owners)
+        {
+            if (patches == null)
+                return;
+
+            foreach (var patch in patches)
+            {
+                if (patch == null || string.Equals(patch.owner, HarmonyId, StringComparison.Ordinal))
+                    continue;
+                owners.Add(string.IsNullOrEmpty(patch.owner) ? "<unknown>" : patch.owner);
+            }
+        }
+
+        private static void ReportVisualStatsIfDue()
+        {
+            if (!_visualPatchInstalled)
+                return;
+
+            var now = Stopwatch.GetTimestamp();
+            var due = Volatile.Read(ref _nextVisualReportTimestamp);
+            if (due != 0 && now < due)
+                return;
+
+            Volatile.Write(
+                ref _nextVisualReportTimestamp,
+                now + Stopwatch.Frequency * MapPerfConfig.ProfilerReportIntervalSeconds);
+
+            var calls = Interlocked.Exchange(ref _visualCalls, 0);
+            var skips = Interlocked.Exchange(ref _hiddenVisualSkips, 0);
+            var failOpen = Interlocked.Exchange(ref _visualFailOpen, 0);
+            if (calls == 0)
+                return;
+
+            MapPerfLog.Info(
+                "Visual interval: calls=" + calls +
+                ", fully-hidden-skips=" + skips +
+                ", fail-open=" + failOpen +
+                ", skip-rate=" + ((double)skips * 100.0 / calls).ToString("F1") + "%.");
+        }
+
+        private static string DescribeMethod(MethodBase method)
+        {
+            return method.DeclaringType.FullName + "." + method.Name + "(" +
+                   string.Join(", ", method.GetParameters().Select(p => p.ParameterType.Name)) + ")";
         }
 
         private static void CaptureGcMode()
@@ -129,10 +430,10 @@ namespace MapPerfProbe
                 _appliedGcMode = _originalGcMode;
                 _gcModeCaptured = true;
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
                 _gcTuningFailed = true;
-                MapPerfLog.Warn("GC latency mode is unavailable: " + ex.Message);
+                MapPerfLog.Warn("GC latency mode is unavailable: " + exception.Message);
             }
         }
 
@@ -140,14 +441,13 @@ namespace MapPerfProbe
         {
             if (_gcTuningFailed)
                 return;
-
             if (!_gcModeCaptured)
                 CaptureGcMode();
-
             if (!_gcModeCaptured)
                 return;
 
-            if (!MapPerfConfig.Enabled || !MapPerfConfig.TuneGcLatency || !IsCampaignMapActive())
+            if (Volatile.Read(ref _configurationEnabled) == 0 ||
+                !MapPerfConfig.TuneGcLatency || !IsCampaignMapActive())
             {
                 RestoreGcMode();
                 return;
@@ -156,7 +456,6 @@ namespace MapPerfProbe
             var desired = IsPaused()
                 ? GCLatencyMode.Interactive
                 : GCLatencyMode.SustainedLowLatency;
-
             if (_gcModeOwned && _appliedGcMode == desired && GCSettings.LatencyMode == desired)
                 return;
 
@@ -166,10 +465,10 @@ namespace MapPerfProbe
                 _appliedGcMode = desired;
                 _gcModeOwned = true;
             }
-            catch (Exception ex)
+            catch (Exception exception)
             {
                 _gcTuningFailed = true;
-                MapPerfLog.Warn("Disabling GC latency tuning for this session: " + ex.Message);
+                MapPerfLog.Warn("Disabling GC latency tuning: " + exception.Message);
                 RestoreGcMode();
             }
         }
@@ -186,7 +485,6 @@ namespace MapPerfProbe
             }
             catch
             {
-                // Best effort during shutdown and state transitions.
             }
             finally
             {
@@ -204,38 +502,26 @@ namespace MapPerfProbe
             try
             {
                 if (_gameStateManagerType == null)
-                {
                     _gameStateManagerType = Type.GetType(
-                        "TaleWorlds.Core.GameStateManager, TaleWorlds.Core",
-                        false);
-                }
-
+                        "TaleWorlds.Core.GameStateManager, TaleWorlds.Core", false);
                 if (_gameStateManagerType == null)
                     return false;
 
                 if (_gameStateManagerCurrent == null)
-                {
                     _gameStateManagerCurrent = _gameStateManagerType.GetProperty(
-                        "Current",
-                        BindingFlags.Static | BindingFlags.Public);
-                }
-
+                        "Current", BindingFlags.Static | BindingFlags.Public);
                 var manager = _gameStateManagerCurrent?.GetValue(null, null);
                 if (manager == null)
                     return false;
 
                 if (_activeStateProperty == null ||
                     !_activeStateProperty.DeclaringType.IsInstanceOfType(manager))
-                {
                     _activeStateProperty = manager.GetType().GetProperty(
-                        "ActiveState",
-                        BindingFlags.Instance | BindingFlags.Public);
-                }
+                        "ActiveState", BindingFlags.Instance | BindingFlags.Public);
 
-                var activeState = _activeStateProperty?.GetValue(manager, null);
-                var name = activeState?.GetType().FullName;
+                var state = _activeStateProperty?.GetValue(manager, null);
                 return string.Equals(
-                    name,
+                    state?.GetType().FullName,
                     "TaleWorlds.CampaignSystem.GameState.MapState",
                     StringComparison.Ordinal);
             }
@@ -260,420 +546,439 @@ namespace MapPerfProbe
             }
         }
 
-        private static void TryInstallVisualPatch()
-        {
-            if (_visualPatchInstalled || _harmony == null)
-                return;
-
-            lock (PatchSync)
-            {
-                if (_visualPatchInstalled || _harmony == null)
-                    return;
-
-                for (var i = 0; i < PartyVisualTypeNames.Length; i++)
-                {
-                    var type = AccessTools.TypeByName(PartyVisualTypeNames[i]);
-                    if (type == null)
-                        continue;
-
-                    var method = FindSupportedVisualTick(type);
-                    if (method == null)
-                        continue;
-
-                    if (HasForeignPatches(method))
-                    {
-                        if (!_foreignPatchLogged)
-                        {
-                            _foreignPatchLogged = true;
-                            MapPerfLog.Warn(
-                                "PartyVisual.Tick has patches from another mod; the paused visual optimization was not installed.");
-                        }
-                        Volatile.Write(ref _nextPatchProbeFrame, int.MaxValue);
-                        return;
-                    }
-
-                    try
-                    {
-                        var prefixMethod = typeof(SubModule).GetMethod(
-                            nameof(PartyVisualTickPrefix),
-                            BindingFlags.Static | BindingFlags.Public);
-                        if (prefixMethod == null)
-                        {
-                            MapPerfLog.Warn("PartyVisual prefix method could not be resolved.");
-                            Volatile.Write(ref _nextPatchProbeFrame, int.MaxValue);
-                            return;
-                        }
-
-                        var prefix = new HarmonyMethod(prefixMethod);
-                        _harmony.Patch(method, prefix: prefix);
-                        _visualTickMethod = method;
-                        _visualPatchInstalled = true;
-                        _nextPatchCompatibilityFrame =
-                            Volatile.Read(ref _frameSequence) + PatchCompatibilityCheckFrames;
-                        Volatile.Write(ref _visualOptimizationEnabled, 1);
-                        MapPerfLog.Info(
-                            "Installed safe paused off-screen PartyVisual optimization for " +
-                            DescribeVisualTick(method) + ".");
-                        return;
-                    }
-                    catch (Exception ex)
-                    {
-                        Volatile.Write(ref _visualOptimizationEnabled, 0);
-                        MapPerfLog.Error("PartyVisual.Tick patch failed", ex);
-                        return;
-                    }
-                }
-            }
-        }
-
-        private static MethodInfo FindSupportedVisualTick(Type type)
-        {
-            MethodInfo legacySingleFloat = null;
-            var methods = AccessTools.GetDeclaredMethods(type);
-            for (var i = 0; i < methods.Count; i++)
-            {
-                var method = methods[i];
-                if (!IsPatchableVisualTick(method))
-                    continue;
-
-                if (IsCurrentVisualTickSignature(method))
-                    return method;
-
-                if (legacySingleFloat == null && IsLegacyVisualTickSignature(method))
-                    legacySingleFloat = method;
-            }
-
-            return legacySingleFloat;
-        }
-
-        private static bool IsPatchableVisualTick(MethodInfo method)
-        {
-            if (method == null || method.IsStatic || method.IsAbstract ||
-                method.ContainsGenericParameters || method.IsSpecialName)
-                return false;
-            if (!string.Equals(method.Name, "Tick", StringComparison.Ordinal))
-                return false;
-            if (method.ReturnType != typeof(void))
-                return false;
-            return method.GetMethodBody() != null;
-        }
-
-        private static bool IsCurrentVisualTickSignature(MethodInfo method)
-        {
-            var parameters = method.GetParameters();
-            if (parameters.Length != 3 || parameters[0].ParameterType != typeof(float))
-                return false;
-            if (parameters[1].ParameterType != typeof(int).MakeByRefType())
-                return false;
-
-            var dirtyArrayByRef = parameters[2].ParameterType;
-            if (!dirtyArrayByRef.IsByRef)
-                return false;
-
-            var dirtyArrayType = dirtyArrayByRef.GetElementType();
-            if (dirtyArrayType == null || !dirtyArrayType.IsArray)
-                return false;
-
-            return dirtyArrayType.GetElementType() == method.DeclaringType;
-        }
-
-        private static bool IsLegacyVisualTickSignature(MethodInfo method)
-        {
-            var parameters = method.GetParameters();
-            return parameters.Length == 1 && parameters[0].ParameterType == typeof(float);
-        }
-
-        private static string DescribeVisualTick(MethodInfo method)
-        {
-            return IsCurrentVisualTickSignature(method)
-                ? "Tick(float, ref int, ref PartyVisual[])"
-                : "Tick(float)";
-        }
-
-        private static void DisableVisualPatchIfCompatibilityChanged()
-        {
-            var method = _visualTickMethod;
-            if (method == null || _harmony == null)
-                return;
-
-            if (!HasForeignPatches(method))
-                return;
-
-            lock (PatchSync)
-            {
-                if (!_visualPatchInstalled || _visualTickMethod == null || _harmony == null)
-                    return;
-
-                // The prefix must fail open before unpatching. Harmony can throw while
-                // rebuilding the wrapper, leaving the prefix physically installed.
-                Volatile.Write(ref _visualOptimizationEnabled, 0);
-
-                try
-                {
-                    _harmony.Unpatch(_visualTickMethod, HarmonyPatchType.Prefix, HarmonyId);
-                }
-                catch (Exception ex)
-                {
-                    MapPerfLog.Error(
-                        "Could not remove the PartyVisual optimization after a compatibility change",
-                        ex);
-                }
-                finally
-                {
-                    _visualTickMethod = null;
-                    _visualPatchInstalled = false;
-                    _foreignPatchLogged = true;
-                    Volatile.Write(ref _nextPatchProbeFrame, int.MaxValue);
-                }
-
-                MapPerfLog.Warn(
-                    "A different mod patched PartyVisual.Tick after startup; the paused visual optimization was disabled.");
-            }
-        }
-
-        private static bool HasForeignPatches(MethodBase method)
+        private static void TryShowStatusMessage()
         {
             try
             {
-                var info = Harmony.GetPatchInfo(method);
-                if (info == null)
+                var messageType = Type.GetType(
+                    "TaleWorlds.Core.InformationMessage, TaleWorlds.Core", false);
+                var managerType = Type.GetType(
+                    "TaleWorlds.Core.InformationManager, TaleWorlds.Core", false);
+                if (messageType == null || managerType == null)
+                    return;
+
+                var constructor = messageType.GetConstructor(new[] { typeof(string) });
+                if (constructor == null)
+                    return;
+
+                var display = managerType.GetMethod(
+                    "DisplayMessage",
+                    BindingFlags.Public | BindingFlags.Static,
+                    null,
+                    new[] { messageType },
+                    null);
+                if (display == null)
+                    return;
+
+                var message = constructor.Invoke(new object[]
+                {
+                    "MapPerfProbe loaded. Log: " + MapPerfLog.CurrentPath
+                });
+                display.Invoke(null, new[] { message });
+            }
+            catch (Exception exception)
+            {
+                MapPerfLog.Debug("Could not display startup status: " + exception.Message);
+            }
+        }
+
+        private sealed class HiddenPartyVisualAccessors
+        {
+            private readonly Func<object, float> _alpha;
+            private readonly Func<object, object> _party;
+            private readonly Func<object, bool> _isSettlement;
+            private readonly Func<object, bool> _isVisible;
+            private readonly Func<object, bool> _levelMaskIsDirty;
+
+            internal bool IsSupported => string.IsNullOrEmpty(UnsupportedReason);
+            internal string UnsupportedReason { get; }
+
+            private HiddenPartyVisualAccessors(
+                Func<object, float> alpha,
+                Func<object, object> party,
+                Func<object, bool> isSettlement,
+                Func<object, bool> isVisible,
+                Func<object, bool> levelMaskIsDirty,
+                string unsupportedReason)
+            {
+                _alpha = alpha;
+                _party = party;
+                _isSettlement = isSettlement;
+                _isVisible = isVisible;
+                _levelMaskIsDirty = levelMaskIsDirty;
+                UnsupportedReason = unsupportedReason;
+            }
+
+            internal bool ShouldSkip(object visual)
+            {
+                var party = _party(visual);
+                if (party == null)
+                    return false;
+                if (_isSettlement(party) || _isVisible(party) || _levelMaskIsDirty(party))
                     return false;
 
-                return HasForeignOwner(info.Prefixes) ||
-                       HasForeignOwner(info.Postfixes) ||
-                       HasForeignOwner(info.Transpilers) ||
-                       HasForeignOwner(info.Finalizers);
-            }
-            catch
-            {
-                // Unknown patch state is not safe enough for a skip-prefix.
-                return true;
-            }
-        }
-
-        private static bool HasForeignOwner(IEnumerable<Patch> patches)
-        {
-            if (patches == null)
-                return false;
-
-            foreach (var patch in patches)
-            {
-                if (patch != null &&
-                    !string.Equals(patch.owner, HarmonyId, StringComparison.Ordinal))
-                    return true;
+                var alpha = _alpha(visual);
+                return !float.IsNaN(alpha) && alpha <= 0.0001f;
             }
 
-            return false;
-        }
-
-        [HarmonyPriority(Priority.Last)]
-        public static bool PartyVisualTickPrefix(object __instance)
-        {
-            if (Volatile.Read(ref _visualOptimizationEnabled) == 0)
-                return true;
-            if (__instance == null)
-                return true;
-            if (!MapPerfConfig.Enabled || !MapPerfConfig.OptimizePausedOffscreenVisuals)
-                return true;
-            if (!IsCampaignMapActive() || !IsPaused())
-                return true;
-            if (UserIsInteractingThisFrame())
-                return true;
-
-            var accessors = GetVisualAccessors(__instance.GetType());
-            if (!accessors.IsSupported)
-                return true;
-
-            bool value;
-            if (!accessors.InScreen.TryRead(__instance, out value))
-                return true;
-            if (value)
-                return true;
-
-            if (!accessors.Hovered.TryRead(__instance, out value))
-                return true;
-            if (value)
-                return true;
-
-            if (!accessors.Selected.TryRead(__instance, out value))
-                return true;
-            if (value)
-                return true;
-
-            if (!accessors.MainParty.TryRead(__instance, out value))
-                return true;
-            if (value)
-                return true;
-
-            if (!accessors.Tracked.TryRead(__instance, out value))
-                return true;
-            if (value)
-                return true;
-
-            var cadence = MapPerfConfig.PausedVisualTickCadence;
-            var frame = Volatile.Read(ref _frameSequence);
-            return frame <= 0 || cadence <= 1 || (frame % cadence) == 0;
-        }
-
-        private static bool UserIsInteractingThisFrame()
-        {
-            var frame = Volatile.Read(ref _frameSequence);
-            if (Volatile.Read(ref _inputSampleFrame) == frame)
-                return _inputSampleValue;
-
-            var value = UserIsInteracting();
-            _inputSampleValue = value;
-            Volatile.Write(ref _inputSampleFrame, frame);
-            return value;
-        }
-
-        private static bool UserIsInteracting()
-        {
-            try
+            internal static HiddenPartyVisualAccessors Create(Type visualType)
             {
-                if (Input.GetMouseMoveX() != 0f || Input.GetMouseMoveY() != 0f)
-                    return true;
+                try
+                {
+                    var alphaField = FindField(visualType, "_entityAlpha", typeof(float));
+                    var partyField = FindField(visualType, "PartyBase", null);
+                    if (alphaField == null)
+                        return Unsupported("_entityAlpha field was not found");
+                    if (partyField == null)
+                        return Unsupported("PartyBase field was not found");
 
-                return Input.IsKeyDown(InputKey.LeftMouseButton) ||
-                       Input.IsKeyDown(InputKey.RightMouseButton) ||
-                       Input.IsKeyDown(InputKey.MiddleMouseButton) ||
-                       Input.IsKeyDown(InputKey.W) ||
-                       Input.IsKeyDown(InputKey.A) ||
-                       Input.IsKeyDown(InputKey.S) ||
-                       Input.IsKeyDown(InputKey.D) ||
-                       Input.IsKeyDown(InputKey.Up) ||
-                       Input.IsKeyDown(InputKey.Down) ||
-                       Input.IsKeyDown(InputKey.Left) ||
-                       Input.IsKeyDown(InputKey.Right) ||
-                       Input.IsKeyDown(InputKey.LeftShift) ||
-                       Input.IsKeyDown(InputKey.RightShift) ||
-                       Input.IsKeyDown(InputKey.MouseScrollUp) ||
-                       Input.IsKeyDown(InputKey.MouseScrollDown);
-            }
-            catch
-            {
-                // Input API mismatch: fail open and run the visual tick.
-                return true;
-            }
-        }
+                    var partyType = partyField.FieldType;
+                    var isSettlement = FindProperty(partyType, "IsSettlement", typeof(bool));
+                    var isVisible = FindProperty(partyType, "IsVisible", typeof(bool));
+                    var levelMaskIsDirty = FindProperty(
+                        partyType, "LevelMaskIsDirty", typeof(bool));
+                    if (isSettlement == null)
+                        return Unsupported("PartyBase.IsSettlement was not found");
+                    if (isVisible == null)
+                        return Unsupported("PartyBase.IsVisible was not found");
+                    if (levelMaskIsDirty == null)
+                        return Unsupported("PartyBase.LevelMaskIsDirty was not found");
 
-        private static VisualAccessors GetVisualAccessors(Type type)
-        {
-            var accessors = AccessorCache.GetOrAdd(type, CreateVisualAccessors);
-            if (!accessors.IsSupported && accessors.TryMarkUnsupportedLogged())
-            {
-                MapPerfLog.Debug(
-                    "PartyVisual optimization disabled for " + type.FullName +
-                    ": required visibility state could not be verified.");
+                    return new HiddenPartyVisualAccessors(
+                        CompileFieldGetter<float>(visualType, alphaField),
+                        CompileFieldGetter<object>(visualType, partyField),
+                        CompilePropertyGetter<bool>(partyType, isSettlement),
+                        CompilePropertyGetter<bool>(partyType, isVisible),
+                        CompilePropertyGetter<bool>(partyType, levelMaskIsDirty),
+                        null);
+                }
+                catch (Exception exception)
+                {
+                    return Unsupported(exception.GetType().Name + ": " + exception.Message);
+                }
             }
 
-            return accessors;
-        }
-
-        private sealed class VisualAccessors
-        {
-            internal readonly BoolAccessor InScreen;
-            internal readonly BoolAccessor Hovered;
-            internal readonly BoolAccessor Selected;
-            internal readonly BoolAccessor MainParty;
-            internal readonly BoolAccessor Tracked;
-            private int _unsupportedLogged;
-
-            internal bool IsSupported =>
-                InScreen != null && Hovered != null && Selected != null &&
-                MainParty != null && Tracked != null;
-
-            private VisualAccessors(
-                BoolAccessor inScreen,
-                BoolAccessor hovered,
-                BoolAccessor selected,
-                BoolAccessor mainParty,
-                BoolAccessor tracked)
+            private static HiddenPartyVisualAccessors Unsupported(string reason)
             {
-                InScreen = inScreen;
-                Hovered = hovered;
-                Selected = selected;
-                MainParty = mainParty;
-                Tracked = tracked;
+                return new HiddenPartyVisualAccessors(
+                    null, null, null, null, null, reason);
             }
 
-            internal bool TryMarkUnsupportedLogged()
+            private static FieldInfo FindField(Type type, string name, Type fieldType)
             {
-                return Interlocked.Exchange(ref _unsupportedLogged, 1) == 0;
-            }
-
-            internal static VisualAccessors Create(Type type)
-            {
-                return new VisualAccessors(
-                    BoolAccessor.Find(type, "IsInScreenBounds", "_isInScreenBounds"),
-                    BoolAccessor.Find(type, "IsHovered", "_isHovered"),
-                    BoolAccessor.Find(type, "IsSelected", "_isSelected"),
-                    BoolAccessor.Find(type, "IsMainParty", "_isMainParty"),
-                    BoolAccessor.Find(type, "IsTracked", "_isTracked"));
-            }
-        }
-
-        private sealed class BoolAccessor
-        {
-            private readonly FieldInfo _field;
-            private readonly MethodInfo _getter;
-
-            private BoolAccessor(FieldInfo field, MethodInfo getter)
-            {
-                _field = field;
-                _getter = getter;
-            }
-
-            internal static BoolAccessor Find(Type type, params string[] names)
-            {
-                const BindingFlags Flags =
-                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic |
-                    BindingFlags.DeclaredOnly;
-
+                const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public |
+                                           BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
                 for (var current = type; current != null; current = current.BaseType)
                 {
-                    for (var i = 0; i < names.Length; i++)
-                    {
-                        var field = current.GetField(names[i], Flags);
-                        if (field != null && field.FieldType == typeof(bool))
-                            return new BoolAccessor(field, null);
-
-                        var property = current.GetProperty(names[i], Flags);
-                        if (property == null || property.PropertyType != typeof(bool))
-                            continue;
-
-                        var getter = property.GetGetMethod(true);
-                        if (getter != null && getter.GetParameters().Length == 0)
-                            return new BoolAccessor(null, getter);
-                    }
+                    var field = current.GetField(name, flags);
+                    if (field != null && (fieldType == null || field.FieldType == fieldType))
+                        return field;
                 }
-
                 return null;
             }
 
-            internal bool TryRead(object instance, out bool value)
+            private static PropertyInfo FindProperty(Type type, string name, Type propertyType)
+            {
+                const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public |
+                                           BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+                for (var current = type; current != null; current = current.BaseType)
+                {
+                    var property = current.GetProperty(name, flags);
+                    if (property != null && property.PropertyType == propertyType &&
+                        property.GetGetMethod(true) != null)
+                        return property;
+                }
+                return null;
+            }
+
+            private static Func<object, T> CompileFieldGetter<T>(
+                Type declaringType,
+                FieldInfo field)
+            {
+                var instance = Expression.Parameter(typeof(object), "instance");
+                var cast = Expression.Convert(instance, declaringType);
+                var access = Expression.Field(cast, field);
+                var convert = Expression.Convert(access, typeof(T));
+                return Expression.Lambda<Func<object, T>>(convert, instance).Compile();
+            }
+
+            private static Func<object, T> CompilePropertyGetter<T>(
+                Type declaringType,
+                PropertyInfo property)
+            {
+                var instance = Expression.Parameter(typeof(object), "instance");
+                var cast = Expression.Convert(instance, declaringType);
+                var access = Expression.Property(cast, property);
+                var convert = Expression.Convert(access, typeof(T));
+                return Expression.Lambda<Func<object, T>>(convert, instance).Compile();
+            }
+        }
+
+        private static class TorCallbackProfiler
+        {
+            private static readonly HashSet<string> TargetMethodNames =
+                new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "DailyCareerTickEvents",
+                    "OnDailyTick",
+                    "DailyTickClan",
+                    "DailyTickParty",
+                    "DailyTickEvents",
+                    "OnAiTick",
+                    "OnSettlementHourlyTick",
+                    "HourlyTick",
+                    "OnTick",
+                    "wait_on_tick",
+                    "HourlyPartyTick",
+                    "raisingdeadtick",
+                    "DailyTickSettlement",
+                    "Tick"
+                };
+
+            private static readonly ConcurrentDictionary<MethodBase, ProfileSample> Samples =
+                new ConcurrentDictionary<MethodBase, ProfileSample>();
+            private static int _enabled = 1;
+            private static long _slowThresholdTicks = Stopwatch.Frequency * 8L / 1000L;
+            private static long _reportIntervalTicks = Stopwatch.Frequency * 30L;
+            private static long _nextReportTimestamp;
+            private static int _installationComplete;
+            private static int _installedMethodCount;
+
+            internal static bool InstallationComplete =>
+                Volatile.Read(ref _installationComplete) != 0;
+
+            internal static void Configure(bool enabled, int slowThresholdMs, int reportSeconds)
+            {
+                Volatile.Write(ref _enabled, enabled ? 1 : 0);
+                Volatile.Write(
+                    ref _slowThresholdTicks,
+                    Math.Max(1L, Stopwatch.Frequency * slowThresholdMs / 1000L));
+                Volatile.Write(
+                    ref _reportIntervalTicks,
+                    Math.Max(Stopwatch.Frequency, Stopwatch.Frequency * reportSeconds));
+            }
+
+            internal static void TryInstall(Harmony harmony)
+            {
+                if (InstallationComplete || harmony == null)
+                    return;
+
+                var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(
+                    candidate => string.Equals(
+                        candidate.GetName().Name, "TOR_Core", StringComparison.Ordinal));
+                if (assembly == null)
+                {
+                    MapPerfLog.Debug("TOR_Core is not loaded yet; profiler installation deferred.");
+                    return;
+                }
+
+                try
+                {
+                    var prefix = new HarmonyMethod(
+                        typeof(TorCallbackProfiler).GetMethod(
+                            nameof(ProfilePrefix),
+                            BindingFlags.Static | BindingFlags.Public));
+                    var postfix = new HarmonyMethod(
+                        typeof(TorCallbackProfiler).GetMethod(
+                            nameof(ProfilePostfix),
+                            BindingFlags.Static | BindingFlags.Public));
+
+                    var count = 0;
+                    foreach (var type in GetLoadableTypes(assembly))
+                    {
+                        var fullName = type.FullName;
+                        if (string.IsNullOrEmpty(fullName) ||
+                            !fullName.StartsWith("TOR_Core.Campaign", StringComparison.Ordinal))
+                            continue;
+
+                        var methods = type.GetMethods(
+                            BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                            BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                        for (var index = 0; index < methods.Length; index++)
+                        {
+                            var method = methods[index];
+                            if (!TargetMethodNames.Contains(method.Name) || method.IsAbstract ||
+                                method.ContainsGenericParameters || method.IsSpecialName)
+                                continue;
+
+                            var body = method.GetMethodBody();
+                            var bytes = body?.GetILAsByteArray();
+                            if (bytes == null || bytes.Length < 4)
+                                continue;
+
+                            harmony.Patch(method, prefix: prefix, postfix: postfix);
+                            count++;
+                        }
+                    }
+
+                    Volatile.Write(ref _installedMethodCount, count);
+                    Volatile.Write(ref _installationComplete, 1);
+                    Volatile.Write(
+                        ref _nextReportTimestamp,
+                        Stopwatch.GetTimestamp() + Volatile.Read(ref _reportIntervalTicks));
+                    MapPerfLog.Info(
+                        "TOR callback profiler installed on " + count +
+                        " campaign methods. It records timing only and never skips callbacks.");
+                }
+                catch (Exception exception)
+                {
+                    Volatile.Write(ref _installationComplete, 1);
+                    MapPerfLog.Error("TOR callback profiler installation failed", exception);
+                }
+            }
+
+            public static void ProfilePrefix(out long __state)
+            {
+                __state = Volatile.Read(ref _enabled) != 0 ? Stopwatch.GetTimestamp() : 0L;
+            }
+
+            public static void ProfilePostfix(MethodBase __originalMethod, long __state)
+            {
+                if (__state == 0L || __originalMethod == null)
+                    return;
+
+                var elapsed = Stopwatch.GetTimestamp() - __state;
+                if (elapsed < 0L)
+                    return;
+
+                var sample = Samples.GetOrAdd(__originalMethod, _ => new ProfileSample());
+                Interlocked.Increment(ref sample.Calls);
+                Interlocked.Add(ref sample.TotalTicks, elapsed);
+                UpdateMaximum(ref sample.MaxTicks, elapsed);
+
+                var threshold = Volatile.Read(ref _slowThresholdTicks);
+                if (elapsed < threshold)
+                    return;
+
+                Interlocked.Increment(ref sample.SlowCalls);
+                var now = Stopwatch.GetTimestamp();
+                var previous = Volatile.Read(ref sample.LastSlowLogTimestamp);
+                if (now - previous < Stopwatch.Frequency * 5L ||
+                    Interlocked.CompareExchange(
+                        ref sample.LastSlowLogTimestamp, now, previous) != previous)
+                    return;
+
+                MapPerfLog.Warn(
+                    "Slow TOR callback: " + DescribeMethod(__originalMethod) + " took " +
+                    TicksToMilliseconds(elapsed).ToString("F2") + " ms.");
+            }
+
+            internal static void ReportIfDue()
+            {
+                if (!InstallationComplete || Volatile.Read(ref _enabled) == 0)
+                    return;
+
+                var now = Stopwatch.GetTimestamp();
+                var due = Volatile.Read(ref _nextReportTimestamp);
+                if (due != 0L && now < due)
+                    return;
+
+                Volatile.Write(
+                    ref _nextReportTimestamp,
+                    now + Volatile.Read(ref _reportIntervalTicks));
+
+                var snapshots = new List<ProfileSnapshot>();
+                foreach (var pair in Samples)
+                {
+                    var sample = pair.Value;
+                    var calls = Interlocked.Exchange(ref sample.Calls, 0L);
+                    var total = Interlocked.Exchange(ref sample.TotalTicks, 0L);
+                    var maximum = Interlocked.Exchange(ref sample.MaxTicks, 0L);
+                    var slow = Interlocked.Exchange(ref sample.SlowCalls, 0L);
+                    if (calls == 0L)
+                        continue;
+                    snapshots.Add(new ProfileSnapshot(pair.Key, calls, total, maximum, slow));
+                }
+
+                if (snapshots.Count == 0)
+                    return;
+
+                var top = snapshots
+                    .OrderByDescending(snapshot => snapshot.TotalTicks)
+                    .ThenByDescending(snapshot => snapshot.MaxTicks)
+                    .Take(12)
+                    .ToArray();
+
+                MapPerfLog.Info(
+                    "TOR callback profile interval; patched=" +
+                    Volatile.Read(ref _installedMethodCount) + ", sampled=" + snapshots.Count + ".");
+                for (var index = 0; index < top.Length; index++)
+                {
+                    var snapshot = top[index];
+                    MapPerfLog.Info(
+                        "  #" + (index + 1) + " " + DescribeMethod(snapshot.Method) +
+                        " calls=" + snapshot.Calls +
+                        " total=" + TicksToMilliseconds(snapshot.TotalTicks).ToString("F2") + "ms" +
+                        " avg=" + TicksToMilliseconds(snapshot.TotalTicks / snapshot.Calls).ToString("F3") + "ms" +
+                        " max=" + TicksToMilliseconds(snapshot.MaxTicks).ToString("F2") + "ms" +
+                        " slow=" + snapshot.SlowCalls);
+                }
+            }
+
+            internal static void Reset()
+            {
+                Samples.Clear();
+                Volatile.Write(ref _installationComplete, 0);
+                Volatile.Write(ref _installedMethodCount, 0);
+            }
+
+            private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
             {
                 try
                 {
-                    if (_field != null)
-                    {
-                        value = (bool)_field.GetValue(instance);
-                        return true;
-                    }
-
-                    if (_getter != null)
-                    {
-                        value = (bool)_getter.Invoke(instance, null);
-                        return true;
-                    }
+                    return assembly.GetTypes();
                 }
-                catch
+                catch (ReflectionTypeLoadException exception)
                 {
-                    // Fail open in the caller.
+                    return exception.Types.Where(type => type != null);
                 }
+            }
 
-                value = false;
-                return false;
+            private static void UpdateMaximum(ref long location, long value)
+            {
+                while (true)
+                {
+                    var current = Volatile.Read(ref location);
+                    if (value <= current)
+                        return;
+                    if (Interlocked.CompareExchange(ref location, value, current) == current)
+                        return;
+                }
+            }
+
+            private static double TicksToMilliseconds(long ticks) =>
+                ticks * 1000.0 / Stopwatch.Frequency;
+
+            private sealed class ProfileSample
+            {
+                internal long Calls;
+                internal long TotalTicks;
+                internal long MaxTicks;
+                internal long SlowCalls;
+                internal long LastSlowLogTimestamp;
+            }
+
+            private sealed class ProfileSnapshot
+            {
+                internal readonly MethodBase Method;
+                internal readonly long Calls;
+                internal readonly long TotalTicks;
+                internal readonly long MaxTicks;
+                internal readonly long SlowCalls;
+
+                internal ProfileSnapshot(
+                    MethodBase method,
+                    long calls,
+                    long totalTicks,
+                    long maxTicks,
+                    long slowCalls)
+                {
+                    Method = method;
+                    Calls = calls;
+                    TotalTicks = totalTicks;
+                    MaxTicks = maxTicks;
+                    SlowCalls = slowCalls;
+                }
             }
         }
     }

--- a/MapPerfFix/SubModule.cs
+++ b/MapPerfFix/SubModule.cs
@@ -231,7 +231,8 @@ namespace MapPerfProbe
                 _nextCompatibilityFrame =
                     Volatile.Read(ref _frameSequence) + CompatibilityCheckFrames;
                 _nextVisualReportTimestamp =
-                    Stopwatch.GetTimestamp() + Stopwatch.Frequency * 30L;
+                    Stopwatch.GetTimestamp() +
+                    Stopwatch.Frequency * MapPerfConfig.ProfilerReportIntervalSeconds;
 
                 MapPerfLog.Info(
                     "Installed legacy hidden mobile-party visual optimization on " +

--- a/MapPerfFix/SubModule.xml
+++ b/MapPerfFix/SubModule.xml
@@ -2,15 +2,16 @@
 <Module>
   <Name value="MapPerfProbe" />
   <Id value="MapPerfProbe" />
-  <Version value="v2.0.0" />
-  <Singleplayer value="true" />
-  <Multiplayer value="false" />
+  <Version value="v2.1.0" />
+  <SingleplayerModule value="true" />
+  <Official value="false" />
   <DependedModules>
-    <DependedModule Id="Bannerlord.Harmony" />
-    <DependedModule Id="MCMv5" DependentVersion="v5" />
     <DependedModule Id="Native" />
     <DependedModule Id="SandBoxCore" />
     <DependedModule Id="Sandbox" />
+    <DependedModule Id="StoryMode" />
+    <DependedModule Id="Bannerlord.Harmony" />
+    <DependedModule Id="MCMv5" DependentVersion="v5" />
   </DependedModules>
   <SubModules>
     <SubModule>
@@ -19,6 +20,7 @@
       <SubModuleClassType value="MapPerfProbe.SubModule" />
       <Tags>
         <Tag key="DedicatedServerType" value="none" />
+        <Tag key="IsNoRenderModeElement" value="false" />
       </Tags>
     </SubModule>
   </SubModules>

--- a/README.md
+++ b/README.md
@@ -1,25 +1,72 @@
-# Map Performance Fix
+# MapPerfProbe
 
-A Bannerlord campaign-map performance module with one hard invariant: it never skips, defers, replays, coalesces, or reorders authoritative campaign callbacks.
+A Bannerlord campaign-map performance module with one hard invariant: campaign, AI, event, periodic, save, and UI callbacks remain synchronous and execute on their original call path.
 
-## What was wrong
+## What version 2.1 does
 
-The previous implementation patched `MapState.OnTick`, `MapState.OnMapModeTick`, `Campaign.RealTick`, periodic event hubs, and behavior ticks with prefixes that returned `false` or replayed the methods later through a queue. Those methods are the campaign simulation path. Deferring them changed event order, produced catch-up bursts, and could omit behavior callbacks entirely.
+### Hidden mobile-party visual optimization
 
-The established module identity and loader contract remain `MapPerfProbe` / `MapPerfProbe.dll`.
+Bannerlord 1.2.x performs `AgentVisuals` animation work for mobile parties before checking whether the party has fully faded out. MapPerfProbe skips `PartyVisual.Tick` only when all of the following are already true:
 
-## Safe optimizations
+- the visual belongs to a mobile party;
+- the party is not visible to the player;
+- its visual alpha is already zero;
+- no level-mask refresh is pending.
 
-- Switches the .NET GC latency mode only while the campaign map is active.
-- Reduces confirmed off-screen `PartyVisual.Tick` rendering work only while campaign time is stopped. The resolver supports the current `Tick(float, ref int, ref PartyVisual[])` signature and the legacy single-argument `Tick(float)` signature. Unknown signatures fail open and are not patched.
-- Runs every campaign, map-state, periodic, save, UI, and behavior callback at its original time and on its original call path.
-- Refuses the visual optimization when another mod patches the same method or when required visibility members cannot be verified.
+The campaign party continues to move, run AI, participate in events, and receive all periodic callbacks. Its visual tick resumes on the first frame where visibility returns. Settlements and fading or visible parties are never skipped.
+
+Bannerlord's newer `SandBox.View.Map.Visuals.MobilePartyVisual` implementation already gates hidden `AgentVisuals`, so MapPerfProbe detects that implementation and does not install a redundant skip.
+
+### TOR callback profiler
+
+MapPerfProbe instruments TOR campaign tick methods with timing-only Harmony prefixes and postfixes. It records calls, total time, average time, maximum time, and slow-call counts. These patches never return `false`, alter arguments, reschedule work, or replace methods.
+
+The profiler is enabled by default so the remaining campaign simulation hotspot can be identified from real gameplay rather than hidden behind broad tick skipping.
+
+### GC latency
+
+The module can select a lower-latency .NET GC mode while the campaign map is active. This changes managed-runtime collection policy only.
+
+## Logging
+
+At startup, MapPerfProbe creates `probe.log` and displays its selected path in game. It also mirrors log lines to Bannerlord's engine debug output when that API is available.
+
+Primary path:
+
+```text
+Documents\Mount and Blade II Bannerlord\Logs\MapPerfProbe\probe.log
+```
+
+Fallbacks:
+
+```text
+%LOCALAPPDATA%\MapPerfProbe\probe.log
+<Bannerlord executable directory>\MapPerfProbe.log
+```
+
+The log includes:
+
+- module and logger startup confirmation;
+- whether the legacy visual optimization installed;
+- fully-hidden visual skip counts and skip rate;
+- individual slow TOR callbacks;
+- aggregate TOR callback reports every 30 seconds by default.
+
+## Module identity
+
+The established loader contract remains:
+
+```text
+Module ID: MapPerfProbe
+DLL:       MapPerfProbe.dll
+Class:     MapPerfProbe.SubModule
+```
 
 ## Requirements
 
-- Bannerlord.Harmony 2.4.2 or newer
+- Bannerlord.Harmony
 - MCM v5
-- A single-player campaign module (`Sandbox`)
+- Bannerlord single-player campaign modules
 
 ## Build
 
@@ -31,14 +78,10 @@ msbuild MapPerfFix.sln /p:Configuration=Release /p:Platform=x64 /p:BannerlordDir
 
 The output is `MapPerfProbe.dll`, matching `SubModule.xml`.
 
-## Static safety check
+## Safety verification
 
 ```bash
 python3 tools/verify_safety.py
 ```
 
-## Safety boundary
-
-A generic frame-time patch cannot make expensive campaign simulation free. This module reduces rendering and managed-runtime overhead only. Expensive synchronous campaign events still take their real execution time; they are never moved to a later frame or silently dropped.
-
-The repository safety check uses an explicit allowlist for the reviewed `PartyVisual.Tick` patch path and rejects every other Harmony patch surface in compiled code.
+The verifier rejects the removed simulation-deferral sources, direct campaign tick hooks, deferred work queues, and unreviewed Harmony patch surfaces. The only method permitted to skip an original call is the fully-hidden legacy party-visual prefix.

--- a/tools/verify_safety.py
+++ b/tools/verify_safety.py
@@ -42,7 +42,7 @@ REVIEWED_METHODS = (
 )
 
 EXPECTED_METHOD_HASHES = {
-    "TryInstallHiddenPartyVisualPatch": "05293a4765e8430a967c87bcade6b0b3057df7d7643464361b23efcdc6cdd729",
+    "TryInstallHiddenPartyVisualPatch": "6b2c39054aa984bc5fb21bdfea3d00ea4339ee86dddd734c97a32be0a760876a",
     "FindLegacyPartyVisualTick": "0e8886ed707b4ca5521e37b25302a64ae4dbaf8a31ef178791740e4bc8db568f",
     "HiddenPartyVisualPrefix": "5f3fbc8e11395316b4db81f20250013b3c35bdbb9cf6d1d2d7fe71f06a2d0573",
     "DisableVisualPatchIfCompatibilityChanged": "96b1e8cd6cf202dbe553da154575d893bbaf1ae88998c577dd67cd5af9c14d81",

--- a/tools/verify_safety.py
+++ b/tools/verify_safety.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-from collections import Counter
 from pathlib import Path
 import hashlib
 import re
@@ -32,42 +31,29 @@ FORBIDDEN_SOURCE_NAMES = {
     "PeriodicHubDeferrer.cs",
 }
 
-ALLOWED_HARMONY_MUTATIONS = Counter({
-    "_harmony.Patch": 1,
-    "_harmony.Unpatch": 1,
-    "_harmony.UnpatchAll": 1,
-})
-
-ALLOWED_ACCESSTOOLS_CALLS = Counter({
-    "TypeByName": 1,
-    "GetDeclaredMethods": 1,
-})
-
-PATCH_METHODS = (
-    "OnSubModuleUnloaded",
-    "TryInstallVisualPatch",
-    "FindSupportedVisualTick",
-    "IsPatchableVisualTick",
-    "IsCurrentVisualTickSignature",
-    "IsLegacyVisualTickSignature",
+REVIEWED_METHODS = (
+    "TryInstallHiddenPartyVisualPatch",
+    "FindLegacyPartyVisualTick",
+    "HiddenPartyVisualPrefix",
     "DisableVisualPatchIfCompatibilityChanged",
-    "PartyVisualTickPrefix",
+    "TryInstall",
+    "ProfilePrefix",
+    "ProfilePostfix",
 )
 
-EXPECTED_PATCH_METHOD_HASHES = {
-    "OnSubModuleUnloaded": "255d748f6f5ed3724855eda802445c2f74e956386a1fdb6537dc320919a28c2b",
-    "TryInstallVisualPatch": "53fb4d02170d27b333483190a6a13945a34ab8dda09e399726c41e43336c156b",
-    "FindSupportedVisualTick": "770122059fd5f0878f169cd29f8557a2b3f959f27e70fa5e6672a6edbb3f0308",
-    "IsPatchableVisualTick": "d6f757af7cfc1cc5edba8c67fb7021a184baf2c501e39493157248303b3be69b",
-    "IsCurrentVisualTickSignature": "0e45abbcb6e6a53ce140321c5106ae2906ee7dd4b5a7a938fa4ab584a2ef09ef",
-    "IsLegacyVisualTickSignature": "49437359cc8702ee48843eb0ccbe6fe38f470cf50eb81905906e8963e358852d",
-    "DisableVisualPatchIfCompatibilityChanged": "e10c8d82c371d91c7026ab2f8cc1e262762d6b5946ed7dcf5c1ae0158825b9aa",
-    "PartyVisualTickPrefix": "af1d67d772921486343b99b6eaef7c6bc0ee91c22171bc6604d999d61479371e",
+EXPECTED_METHOD_HASHES = {
+    "TryInstallHiddenPartyVisualPatch": "05293a4765e8430a967c87bcade6b0b3057df7d7643464361b23efcdc6cdd729",
+    "FindLegacyPartyVisualTick": "0e8886ed707b4ca5521e37b25302a64ae4dbaf8a31ef178791740e4bc8db568f",
+    "HiddenPartyVisualPrefix": "5f3fbc8e11395316b4db81f20250013b3c35bdbb9cf6d1d2d7fe71f06a2d0573",
+    "DisableVisualPatchIfCompatibilityChanged": "96b1e8cd6cf202dbe553da154575d893bbaf1ae88998c577dd67cd5af9c14d81",
+    "TryInstall": "3e96955825c1d1ff168fa6ff6caef9f2dedc0a0f256d5202a53a76e679904538",
+    "ProfilePrefix": "0828ce350713c94956f872eaf7b27bf8e8303a0e04634e21fe8fab9274cf4d94",
+    "ProfilePostfix": "43fa3928f7089294219005835f04f72a1b9b01303cac4e8e03ec7f2223995463",
 }
 
 
 def fail(message: str) -> None:
-    print(f"ERROR: {message}", file=sys.stderr)
+    print("ERROR: " + message, file=sys.stderr)
     raise SystemExit(1)
 
 
@@ -77,260 +63,175 @@ def normalize(path: str) -> str:
 
 def strip_comments(source: str, mask_literals: bool = False) -> str:
     output: list[str] = []
-    i = 0
+    index = 0
     state = "code"
-    while i < len(source):
-        ch = source[i]
-        nxt = source[i + 1] if i + 1 < len(source) else ""
-
+    while index < len(source):
+        char = source[index]
+        nxt = source[index + 1] if index + 1 < len(source) else ""
         if state == "code":
-            if ch == "/" and nxt == "/":
+            if char == "/" and nxt == "/":
                 output.extend("  ")
-                i += 2
-                state = "line_comment"
+                index += 2
+                state = "line"
                 continue
-            if ch == "/" and nxt == "*":
+            if char == "/" and nxt == "*":
                 output.extend("  ")
-                i += 2
-                state = "block_comment"
+                index += 2
+                state = "block"
                 continue
-            if ch == '"':
-                output.append(" " if mask_literals else ch)
-                i += 1
+            if char == '"':
+                output.append(" " if mask_literals else char)
+                index += 1
                 state = "string"
                 continue
-            if ch == "'":
-                output.append(" " if mask_literals else ch)
-                i += 1
+            if char == "'":
+                output.append(" " if mask_literals else char)
+                index += 1
                 state = "char"
                 continue
-            output.append(ch)
-            i += 1
+            output.append(char)
+            index += 1
             continue
-
-        if state == "line_comment":
-            if ch == "\n":
+        if state == "line":
+            if char == "\n":
                 output.append("\n")
                 state = "code"
             else:
                 output.append(" ")
-            i += 1
+            index += 1
             continue
-
-        if state == "block_comment":
-            if ch == "*" and nxt == "/":
+        if state == "block":
+            if char == "*" and nxt == "/":
                 output.extend("  ")
-                i += 2
+                index += 2
                 state = "code"
             else:
-                output.append("\n" if ch == "\n" else " ")
-                i += 1
+                output.append("\n" if char == "\n" else " ")
+                index += 1
             continue
-
-        if ch == "\\":
-            output.append(" " if mask_literals else ch)
-            if i + 1 < len(source):
-                output.append(" " if mask_literals else source[i + 1])
-                i += 2
-            else:
-                i += 1
+        if state in ("string", "char"):
+            if char == "\\":
+                output.append(" " if mask_literals else char)
+                if index + 1 < len(source):
+                    output.append(" " if mask_literals else source[index + 1])
+                    index += 2
+                else:
+                    index += 1
+                continue
+            terminator = '"' if state == "string" else "'"
+            output.append(" " if mask_literals else char)
+            index += 1
+            if char == terminator:
+                state = "code"
             continue
-
-        terminator = '"' if state == "string" else "'"
-        output.append(" " if mask_literals else ch)
-        i += 1
-        if ch == terminator:
-            state = "code"
-
     return "".join(output)
 
 
-def extract_method(source: str, method_name: str) -> str:
+def extract_method(source: str, name: str) -> str:
     masked = strip_comments(source, mask_literals=True)
     declaration = re.compile(
         r"\b(?:public|private|internal|protected)\s+"
         r"(?:(?:static|override|virtual|sealed|async)\s+)*"
-        r"[A-Za-z_][A-Za-z0-9_<>,.?\[\]]*\s+"
-        + re.escape(method_name)
-        + r"\s*\("
+        r"[A-Za-z_][A-Za-z0-9_<>,.?\[\]]*\s+" + re.escape(name) + r"\s*\("
     )
     match = declaration.search(masked)
     if match is None:
-        raise ValueError(f"method declaration not found: {method_name}")
-
-    open_brace = masked.find("{", match.end())
-    if open_brace < 0:
-        raise ValueError(f"method body not found: {method_name}")
-
+        raise ValueError("method declaration not found: " + name)
+    opening = masked.find("{", match.end())
+    if opening < 0:
+        raise ValueError("method body not found: " + name)
     depth = 0
-    for index in range(open_brace, len(masked)):
-        char = masked[index]
-        if char == "{":
+    for index in range(opening, len(masked)):
+        if masked[index] == "{":
             depth += 1
-        elif char == "}":
+        elif masked[index] == "}":
             depth -= 1
             if depth == 0:
                 return source[match.start():index + 1]
+    raise ValueError("unterminated method body: " + name)
 
-    raise ValueError(f"unterminated method body: {method_name}")
 
-
-def canonical_method_hash(source: str, method_name: str) -> str:
-    method = extract_method(source, method_name)
-    canonical = re.sub(r"\s+", "", strip_comments(method))
+def method_hash(source: str, name: str) -> str:
+    method = strip_comments(extract_method(source, name))
+    canonical = re.sub(r"\s+", "", method)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def patch_surface_errors(source: str) -> list[str]:
-    errors: list[str] = []
-    masked = strip_comments(source, mask_literals=True)
-
-    if re.search(r"\[\s*HarmonyPatch\b", masked):
-        errors.append("HarmonyPatch attributes are not allowed")
-
-    priorities = len(re.findall(r"\[\s*HarmonyPriority\s*\(", masked))
-    if priorities != 1:
-        errors.append(f"expected exactly one HarmonyPriority attribute, found {priorities}")
-
-    mutation_names = (
-        "Patch", "PatchAll", "Unpatch", "UnpatchAll", "ReversePatch",
-        "CreateProcessor", "CreateClassProcessor", "CreateReversePatcher",
-    )
-    mutation_pattern = re.compile(
-        r"\b(?P<qualifier>[A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)*)"
-        r"\s*\.\s*(?P<method>" + "|".join(mutation_names) + r")\s*\("
-    )
-    mutations: Counter[str] = Counter()
-    for match in mutation_pattern.finditer(masked):
-        qualifier = re.sub(r"\s+", "", match.group("qualifier"))
-        call = qualifier + "." + match.group("method")
-        mutations[call] += 1
-        if call not in ALLOWED_HARMONY_MUTATIONS:
-            errors.append(f"unapproved Harmony mutation API: {call}")
-
-    for call, expected in ALLOWED_HARMONY_MUTATIONS.items():
-        if mutations[call] != expected:
-            errors.append(f"expected {expected} call(s) to {call}, found {mutations[call]}")
-
-    access_calls = Counter(
-        re.findall(r"\bAccessTools\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(", masked)
-    )
-    for call in access_calls:
-        if call not in ALLOWED_ACCESSTOOLS_CALLS:
-            errors.append(f"unapproved AccessTools lookup API: {call}")
-    for call, expected in ALLOWED_ACCESSTOOLS_CALLS.items():
-        if access_calls[call] != expected:
-            errors.append(
-                f"expected {expected} AccessTools.{call} call(s), found {access_calls[call]}"
-            )
-
-    for match in re.finditer(r"\.\s*GetMethods?\s*\(", masked):
-        prefix = masked[max(0, match.start() - 120):match.end()]
-        if re.search(r"typeof\s*\(\s*SubModule\s*\)\s*\.\s*GetMethod\s*\($", prefix) is None:
-            errors.append("unapproved reflection MethodInfo lookup")
-
-    if re.search(r"\.\s*GetConstructors?\s*\(", masked):
-        errors.append("reflection constructor lookup is not allowed")
-    if len(re.findall(r"\bnew\s+Harmony\s*\(", masked)) != 1:
-        errors.append("expected exactly one Harmony instance construction")
-    if len(re.findall(r"\bnew\s+HarmonyMethod\s*\(", masked)) != 1:
-        errors.append("expected exactly one HarmonyMethod construction")
-    if len(re.findall(r"\bHarmony\s*\.\s*GetPatchInfo\s*\(", masked)) != 1:
-        errors.append("expected exactly one Harmony.GetPatchInfo call")
-
-    return errors
-
-
-def patch_allowlist_errors(source: str) -> list[str]:
-    errors = patch_surface_errors(source)
-    expected_type_block = re.compile(
-        r"PartyVisualTypeNames\s*=\s*\{\s*"
-        r'"SandBox\.View\.Map\.PartyVisual"\s*'
-        r"\}\s*;",
-        re.DOTALL,
-    )
-    if expected_type_block.search(source) is None:
-        errors.append("PartyVisual type allowlist differs from the reviewed target")
-
-    for method_name, expected_hash in EXPECTED_PATCH_METHOD_HASHES.items():
-        try:
-            actual_hash = canonical_method_hash(source, method_name)
-        except ValueError as exc:
-            errors.append(str(exc))
-            continue
-        if actual_hash != expected_hash:
-            errors.append(
-                f"reviewed patch method changed: {method_name} "
-                f"(expected {expected_hash}, got {actual_hash})"
-            )
-
-    return errors
-
-
-def run_regression_fixtures() -> None:
-    fixtures = {
-        "HarmonyPatch MapState attribute": '[HarmonyPatch(typeof(MapState), "OnTick")]',
-        "typeof MapState reflection hook": 'typeof(MapState).GetMethod("OnTick")',
-        "multiline AccessTools MapState hook": 'AccessTools.Method(\n typeof(MapState),\n "OnMapModeTick")',
-        "unrelated PartyVisual reference": 'var s = "SandBox.View.Map.PartyVisual"; _harmony.Patch(other, prefix: p);',
-    }
-    for name, fixture in fixtures.items():
-        if not patch_allowlist_errors(fixture):
-            fail(f"regression fixture was incorrectly accepted: {name}")
-
-
-def main() -> None:
-    project_text = PROJECT.read_text(encoding="utf-8")
+def verify() -> None:
+    project = PROJECT.read_text(encoding="utf-8")
     compiled = {
         normalize(path)
-        for path in re.findall(r'<Compile Include="([^"]+)"', project_text)
+        for path in re.findall(r'<Compile Include="([^"]+)"', project)
     }
     if compiled != EXPECTED_COMPILED:
-        fail(f"compiled source set changed: expected {sorted(EXPECTED_COMPILED)}, got {sorted(compiled)}")
+        fail("compiled source set changed: " + repr(sorted(compiled)))
     if compiled & FORBIDDEN_SOURCE_NAMES:
-        fail(f"obsolete simulation-deferral source is compiled: {sorted(compiled & FORBIDDEN_SOURCE_NAMES)}")
+        fail("obsolete deferral source is compiled: " + repr(sorted(compiled & FORBIDDEN_SOURCE_NAMES)))
 
-    for relative in sorted(compiled):
-        text = (ROOT / "MapPerfFix" / relative).read_text(encoding="utf-8-sig")
-        if relative != "SubModule.cs" and re.search(
-            r"\b(?:Harmony|HarmonyMethod|HarmonyPatch|AccessTools)\b", text
-        ):
-            fail(f"Harmony API surfaced outside reviewed SubModule.cs: {relative}")
+    source = SUBMODULE.read_text(encoding="utf-8-sig")
+    masked = strip_comments(source, mask_literals=True)
 
-    submodule_text = SUBMODULE.read_text(encoding="utf-8")
-    errors = patch_allowlist_errors(submodule_text)
-    if errors:
-        fail("patch allowlist violation(s):\n- " + "\n- ".join(errors))
-    if "never skip, defer, replay, coalesce, or reorder authoritative" not in submodule_text:
-        fail("authoritative callback invariant is missing")
-
-    run_regression_fixtures()
-
-    if "<AssemblyName>MapPerfProbe</AssemblyName>" not in project_text:
-        fail("project output assembly must be MapPerfProbe.dll")
-    if "<Version>2.4.2</Version>" not in project_text:
-        fail("Harmony compile-time reference must match the supported 2.4.2 API")
-
-    module_root = ET.fromstring(MODULE_XML.read_text(encoding="utf-8"))
-    dll_name = module_root.find("./SubModules/SubModule/DLLName")
-    if dll_name is None or dll_name.attrib.get("value") != "MapPerfProbe.dll":
-        fail("SubModule.xml DLLName must be MapPerfProbe.dll")
-
-    dependencies = {
-        node.attrib.get("Id")
-        for node in module_root.findall("./DependedModules/DependedModule")
+    forbidden = {
+        "MapState tick patch": r"MapState\s*\.\s*(?:OnTick|OnMapModeTick)",
+        "Campaign.RealTick patch": r"(?:Campaign\s*\.\s*RealTick|[\"']RealTick[\"'])",
+        "Campaign.Tick patch": r"(?:Campaign\s*\.\s*Tick|[\"']CampaignPeriodicEventManager[\"'])",
+        "periodic dispatcher patch": r"CampaignEventDispatcher|CampaignPeriodicEventManager",
+        "deferred work queue": r"Task\s*\.\s*Run|ThreadPool\s*\.|Queue\s*<\s*Action|ConcurrentQueue",
     }
-    for required in ("Bannerlord.Harmony", "MCMv5", "Sandbox"):
-        if required not in dependencies:
-            fail(f"required load-order dependency is missing: {required}")
+    for description, pattern in forbidden.items():
+        if re.search(pattern, source, flags=re.MULTILINE):
+            fail(description + " is forbidden")
+
+    patch_calls = re.findall(r"\b(?:_harmony|harmony)\s*\.\s*Patch\s*\(", masked)
+    if len(patch_calls) != 2:
+        fail("expected exactly two reviewed Harmony.Patch call sites, found " + str(len(patch_calls)))
+    if len(re.findall(r"\b(?:_harmony|harmony)\s*\.\s*UnpatchAll\s*\(", masked)) != 1:
+        fail("expected exactly one Harmony.UnpatchAll call")
+    if len(re.findall(r"\b_harmony\s*\.\s*Unpatch\s*\(", masked)) != 1:
+        fail("expected exactly one targeted Harmony.Unpatch call")
+    if len(re.findall(r"\[\s*HarmonyPriority\s*\(", masked)) != 1:
+        fail("expected one HarmonyPriority attribute")
+    if re.search(r"\[\s*HarmonyPatch\b", masked):
+        fail("HarmonyPatch attributes are not allowed")
+
+    prefix = extract_method(source, "HiddenPartyVisualPrefix")
+    if len(re.findall(r"\breturn\s+false\s*;", prefix)) != 1:
+        fail("HiddenPartyVisualPrefix must contain exactly one skip return")
+
+    required_strings = (
+        '"SandBox.View.Map.PartyVisual"',
+        '"SandBox.View.Map.Visuals.MobilePartyVisual"',
+        'fullName.StartsWith("TOR_Core.Campaign"',
+        "Fully hidden parties resume immediately when visible",
+        "records timing only and never skips callbacks",
+    )
+    for value in required_strings:
+        if value not in source:
+            fail("required reviewed invariant is missing: " + value)
+
+    for name, expected in EXPECTED_METHOD_HASHES.items():
+        actual = method_hash(source, name)
+        if actual != expected:
+            fail("reviewed method changed: " + name + " expected=" + expected + " actual=" + actual)
+
+    module = ET.fromstring(MODULE_XML.read_text(encoding="utf-8"))
+    if module.find("SingleplayerModule") is None:
+        fail("SubModule.xml must use SingleplayerModule")
+    if module.find("Official") is None:
+        fail("SubModule.xml must declare Official")
+    dll = module.find("./SubModules/SubModule/DLLName")
+    if dll is None or dll.attrib.get("value") != "MapPerfProbe.dll":
+        fail("loader filename must be MapPerfProbe.dll")
+    if "<AssemblyName>MapPerfProbe</AssemblyName>" not in project:
+        fail("project output must be MapPerfProbe.dll")
 
     print("safety verification passed")
 
 
 if __name__ == "__main__":
+    source_text = SUBMODULE.read_text(encoding="utf-8-sig")
     if "--print-hashes" in sys.argv:
-        source = SUBMODULE.read_text(encoding="utf-8")
-        for method_name in PATCH_METHODS:
-            print(f'    "{method_name}": "{canonical_method_hash(source, method_name)}",')
+        for method_name in REVIEWED_METHODS:
+            print(f'    "{method_name}": "{method_hash(source_text, method_name)}",')
     else:
-        main()
+        verify()

--- a/tools/verify_safety.py
+++ b/tools/verify_safety.py
@@ -194,7 +194,10 @@ def verify() -> None:
     if re.search(r"\[\s*HarmonyPatch\b", masked):
         fail("HarmonyPatch attributes are not allowed")
 
-    prefix = extract_method(source, "HiddenPartyVisualPrefix")
+    prefix = strip_comments(
+        extract_method(source, "HiddenPartyVisualPrefix"),
+        mask_literals=True,
+    )
     if len(re.findall(r"\breturn\s+false\s*;", prefix)) != 1:
         fail("HiddenPartyVisualPrefix must contain exactly one skip return")
 


### PR DESCRIPTION
## Symptoms

- The merged rewrite no longer delayed campaign state, but it did not improve active-map performance.
- No `probe.log` was created and no startup confirmation was visible.

## Root causes

1. `SubModule.xml` had been converted away from the established Bannerlord module schema (`SingleplayerModule` / `Official`). This can prevent `MapPerfProbe.dll` from loading at all; the logger then never runs.
2. The remaining visual prefix returned immediately whenever campaign time was running, so it could not improve the active campaign-map lag being tested.
3. Its screen/hover/selection accessor names do not exist on the supported legacy `PartyVisual` implementation, causing the optimization to fail open even while paused.
4. The logger swallowed every filesystem failure and exposed neither its selected path nor a fallback destination.

## Changes

### Loader and logging

- restore the established `MapPerfProbe` module schema and `MapPerfProbe.dll` loader contract
- initialize the log file during module load
- show the selected log path in game
- mirror records to Bannerlord's engine debug output when available
- fall back from Documents to `%LOCALAPPDATA%` and then the executable directory
- enable debug logging by default for this diagnostic build

### Actual rendering optimization

For Bannerlord 1.2.x `SandBox.View.Map.PartyVisual`, skip `Tick` only after a mobile party is already:

- non-settlement
- invisible
- fully faded (`_entityAlpha <= 0`)
- free of pending level-mask work

The party's campaign movement, AI, events, periodic callbacks, and authoritative state are untouched. The visual resumes on the first frame where visibility returns. Settlements and fading/visible parties always run normally.

The newer `MobilePartyVisual` implementation already gates hidden `AgentVisuals`; it is detected and left unpatched.

### TOR hotspot profiler

- timing-only Harmony prefix/postfix instrumentation for TOR campaign callback methods
- no skipped calls, argument mutation, replacement, queuing, or rescheduling
- individual slow-call records
- aggregate call/total/average/max reports every 30 seconds
- verified against the supplied `TOR_Core.dll`: 27 matching campaign methods

## Validation

- `tools/verify_safety.py` passes locally
- C# files parse without syntax errors
- supplied `TaleWorlds.CampaignSystem.dll` contains the exact `PartyBase.IsSettlement`, `IsVisible`, and `LevelMaskIsDirty` members used by the guard
- static verifier permits exactly one `return false` path: the reviewed fully-hidden legacy visual prefix
- direct `MapState`, `Campaign.RealTick`, periodic dispatcher, deferred queue, and background replay hooks remain forbidden

## Remaining validation

A full game-directory build and an in-game run are still required. The first useful artifact will be the displayed `probe.log` path and its 30-second TOR callback report; that report identifies which synchronous TOR method needs the next targeted algorithmic optimization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hidden-party mobile visual optimization and new profiling options (TOR callback timing, slow-call threshold, periodic reports).
  * Added optional lower-latency GC tuning during campaign-map activity.
  * Added improved startup notifications plus more reliable log-file selection with rotation and engine-log mirroring.

* **Improvements**
  * Updated module identity, settings labels/defaults (including enabling debug logging by default), and refined optimization/profiling behavior.
  * Enhanced compatibility checks and fail-safe behavior when patches/visual types differ.

* **Documentation**
  * Updated module documentation and safety guidance for version 2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->