### PR TITLE
Preserve MapPerfProbe 2.1.2 release

### DIFF
--- a/.github/workflows/preserve-v2.1.2.yml
+++ b/.github/workflows/preserve-v2.1.2.yml
@@ -1,0 +1,48 @@
+name: Preserve MapPerfProbe 2.1.2
+
+on:
+  push:
+    branches:
+      - automation/preserve-v2.1.2
+
+permissions:
+  contents: write
+
+jobs:
+  preserve-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create preserved tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: 81f0d5a210885d1e5d5a1cc647242f5dbe9a91f3
+          TAG: v2.1.2
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            existing="$(git rev-list -n 1 "${TAG}")"
+            if [[ "${existing}" != "${TARGET_SHA}" ]]; then
+              echo "${TAG} already points to ${existing}, expected ${TARGET_SHA}" >&2
+              exit 1
+            fi
+          else
+            git tag -a "${TAG}" "${TARGET_SHA}" -m "MapPerfProbe 2.1.2 preserved before the Bannerlord 1.3.15 / ToR WiTM 1.16 update"
+            git push origin "refs/tags/${TAG}"
+          fi
+
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists."
+          else
+            gh release create "${TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --verify-tag \
+              --title "MapPerfProbe 2.1.2 — preserved legacy release" \
+              --notes $'Preserved snapshot of the existing MapPerfProbe 2.1.2 code before updating the project for Bannerlord 1.3.15 and The Old Realms: War in the Mountains 1.16.\n\nTarget commit: `81f0d5a210885d1e5d5a1cc647242f5dbe9a91f3`.\n\nThis release preserves the prior source and loader contract. GitHub provides source ZIP and tar.gz archives automatically.'
+          fi

--- a/.github/workflows/preserve-v2.1.2.yml
+++ b/.github/workflows/preserve-v2.1.2.yml
@@ -3,6 +3,7 @@ name: Preserve MapPerfProbe 2.1.2
 on:
   push:
     branches:
+      - master
       - automation/preserve-v2.1.2
   pull_request:
     branches:

--- a/.github/workflows/preserve-v2.1.2.yml
+++ b/.github/workflows/preserve-v2.1.2.yml
@@ -4,12 +4,16 @@ on:
   push:
     branches:
       - automation/preserve-v2.1.2
+  pull_request:
+    branches:
+      - master
 
 permissions:
   contents: write
 
 jobs:
   preserve-release:
+    if: github.event_name == 'push' || github.head_ref == 'automation/preserve-v2.1.2'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Temporary automation PR used only to create the preserved `v2.1.2` tag and GitHub release for commit `81f0d5a210885d1e5d5a1cc647242f5dbe9a91f3` before the Bannerlord 1.3.15 / ToR WiTM 1.16 update. This PR will not be merged.