### PR TITLE
Preserve MapPerfProbe 2.1.2 release before 1.3.15 update

### DIFF
--- a/.github/workflows/preserve-v2.1.2.yml
+++ b/.github/workflows/preserve-v2.1.2.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/preserve-v2.1.2.yml
+++ b/.github/workflows/preserve-v2.1.2.yml
@@ -125,6 +125,8 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --force --tags origin
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
             existing="$(git rev-list -n 1 "${TAG}")"


### PR DESCRIPTION
Runs an isolated, idempotent preservation job for the exact pre-update commit `81f0d5a210885d1e5d5a1cc647242f5dbe9a91f3`.

The workflow:
- compiles the untouched 2.1.2 snapshot;
- verifies version synchronization and safety invariants;
- creates tag `v2.1.2` on the exact old commit;
- publishes a GitHub release with a compiled legacy module ZIP.

No production source is changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release automation to also run for pull requests targeting the master branch.
  * Adjusted the release/tag creation step to use the GitHub Actions bot identity for tag and artifact operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->