### PR TITLE
Temporary Player Settlement 1.3.15 compatibility build

### DIFF
--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,1 +1,1 @@
-Build attempt 4: external script diagnostics for BOTLANNER/BannerlordPlayerSettlement commit 52d86c7480778afb83e476ac742895f73fbf6d7f against Bannerlord 1.3.15.
+Build attempt 5: corrected shallow source checkout for BOTLANNER/BannerlordPlayerSettlement commit 52d86c7480778afb83e476ac742895f73fbf6d7f against Bannerlord 1.3.15.

--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,0 +1,1 @@
+Build attempt 2: BOTLANNER/BannerlordPlayerSettlement commit 52d86c7480778afb83e476ac742895f73fbf6d7f against Bannerlord 1.3.15 reference assemblies.

--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,1 +1,1 @@
-Build attempt 3: focused diagnostics for BOTLANNER/BannerlordPlayerSettlement commit 52d86c7480778afb83e476ac742895f73fbf6d7f against Bannerlord 1.3.15.
+Build attempt 4: external script diagnostics for BOTLANNER/BannerlordPlayerSettlement commit 52d86c7480778afb83e476ac742895f73fbf6d7f against Bannerlord 1.3.15.

--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,1 +1,1 @@
-Build attempt 5: corrected shallow source checkout for BOTLANNER/BannerlordPlayerSettlement commit 52d86c7480778afb83e476ac742895f73fbf6d7f against Bannerlord 1.3.15.
+Build attempt 6: compile and Harmony patch-target validation for Player Settlement 7.5.1 against Bannerlord 1.3.15.

--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,1 +1,1 @@
-Build attempt 9: final patch-target validation with null-safe Harmony result reporting.
+Build attempt 10: final Harmony validation restricted to BannerlordPlayerSettlement.Patches.

--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,1 +1,1 @@
-Build attempt 2: BOTLANNER/BannerlordPlayerSettlement commit 52d86c7480778afb83e476ac742895f73fbf6d7f against Bannerlord 1.3.15 reference assemblies.
+Build attempt 3: focused diagnostics for BOTLANNER/BannerlordPlayerSettlement commit 52d86c7480778afb83e476ac742895f73fbf6d7f against Bannerlord 1.3.15.

--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,1 +1,1 @@
-Build attempt 7: compile and patch-target validation with Bannerlord 1.3.15 runtime reference DLLs copied beside the validator.
+Build attempt 8: compile and patch-target validation with explicit ref/net472 Bannerlord DLL copying.

--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,1 +1,1 @@
-Build attempt 6: compile and Harmony patch-target validation for Player Settlement 7.5.1 against Bannerlord 1.3.15.
+Build attempt 7: compile and patch-target validation with Bannerlord 1.3.15 runtime reference DLLs copied beside the validator.

--- a/_player_settlement_build/request.txt
+++ b/_player_settlement_build/request.txt
@@ -1,1 +1,1 @@
-Build attempt 8: compile and patch-target validation with explicit ref/net472 Bannerlord DLL copying.
+Build attempt 9: final patch-target validation with null-safe Harmony result reporting.


### PR DESCRIPTION
Temporary compatibility-build PR used to compile and validate Player Settlement 7.5.1 against Bannerlord 1.3.15. The build completed and the temporary workflow/scripts were removed from `master`.