### PR TITLE
Temporary Player Settlement startup fix build

### DIFF
--- a/_player_settlement_startup_fix_trigger/run.txt
+++ b/_player_settlement_startup_fix_trigger/run.txt
@@ -1,0 +1,1 @@
+Build Player Settlement 7.5.2 startup fix against Bannerlord 1.3.15.

--- a/_player_settlement_startup_fix_trigger/run.txt
+++ b/_player_settlement_startup_fix_trigger/run.txt
@@ -1,1 +1,2 @@
 Build Player Settlement 7.5.2 startup fix against Bannerlord 1.3.15.
+Attempt 2: line-ending-independent source patch.


### PR DESCRIPTION
Temporary build-only PR used to compile Player Settlement 7.5.2 with the guarded compatibility-discovery startup fix for Bannerlord 1.3.15 and ToR WiTM 1.16. The package was collected and all temporary workflow files were removed.