### PR TITLE
Temporary Player Settlement 7.5.5 save-reload fix build

### DIFF
--- a/.github/workflows/temp-player-settlement-v755.yml
+++ b/.github/workflows/temp-player-settlement-v755.yml
@@ -1,0 +1,40 @@
+name: Temporary Player Settlement 7.5.5 build
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_temp_player_settlement_v755/**'
+      - '.github/workflows/temp-player-settlement-v755.yml'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download validated 7.5.4 native-visual build inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: player-settlement-native-visuals
+          path: _downloaded_native
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: xmarre/MapPerfFix
+          run-id: 29352502369
+
+      - name: Build Player Settlement 7.5.5
+        shell: pwsh
+        run: ./_temp_player_settlement_v755/build.ps1
+
+      - name: Upload DLL and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-settlement-v755-save-reload-fix
+          path: _player_settlement_v755_build/out
+          if-no-files-found: error

--- a/_temp_player_settlement_v755/SaveHandler.cs
+++ b/_temp_player_settlement_v755/SaveHandler.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Reflection;
+
+using HarmonyLib;
+using SandBox;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade;
+using TaleWorlds.SaveSystem;
+using TaleWorlds.SaveSystem.Load;
+
+namespace BannerlordPlayerSettlement
+{
+    public class SaveHandler
+    {
+        public enum SaveMechanism
+        {
+            Overwrite = 0,
+            Auto = 1,
+            Temporary = 2
+        }
+
+        private static readonly SaveHandler _instance = new SaveHandler();
+        public static SaveHandler Instance => _instance;
+
+        private static readonly PropertyInfo ActiveSaveSlotNameProp = AccessTools.Property(typeof(MBSaveLoad), "ActiveSaveSlotName");
+        private static readonly MethodInfo GetNextAvailableSaveNameMethod = AccessTools.Method(typeof(MBSaveLoad), "GetNextAvailableSaveName");
+
+        private bool _saveLoadInProgress;
+        private bool _deferredLoadPending;
+        private int _deferredLoadTicks;
+        private SaveMechanism _deferredSaveMechanism;
+        private string? _deferredOriginalSaveName;
+        private string? _deferredNewSaveGameName;
+
+        public static void SaveLoad(SaveMechanism saveMechanism = SaveMechanism.Overwrite, Action<SaveMechanism, string>? afterSave = null)
+        {
+            Instance.SaveAndLoad(saveMechanism, afterSave);
+        }
+
+        public static void SaveOnly(bool overwrite = true)
+        {
+            Instance.Save(overwrite);
+        }
+
+        public void SaveAndLoad(SaveMechanism saveMechanism = SaveMechanism.Overwrite, Action<SaveMechanism, string>? afterSave = null)
+        {
+            if (_saveLoadInProgress)
+            {
+                return;
+            }
+
+            string saveName = (string)ActiveSaveSlotNameProp.GetValue(null);
+            if (saveName == null)
+            {
+                saveName = (string)GetNextAvailableSaveNameMethod.Invoke(null, Array.Empty<object>());
+                ActiveSaveSlotNameProp.SetValue(null, saveName);
+            }
+
+            _saveLoadInProgress = true;
+            CampaignEvents.OnSaveOverEvent.ClearListeners(this);
+            CampaignEvents.OnSaveOverEvent.AddNonSerializedListener(this,
+                new Action<bool, string>((successful, writtenName) =>
+                    ApplyInternal(saveMechanism, saveName, successful, writtenName, afterSave)));
+
+            try
+            {
+                if (saveMechanism == SaveMechanism.Overwrite)
+                {
+                    Campaign.Current.SaveHandler.SaveAs(saveName);
+                }
+                else
+                {
+                    Campaign.Current.SaveHandler.SaveAs(saveName + new TextObject("{=player_settlement_n_02} (auto)").ToString());
+                }
+            }
+            catch
+            {
+                ResetPendingState();
+                throw;
+            }
+        }
+
+        public void Save(bool overwrite = true)
+        {
+            string saveName = (string)ActiveSaveSlotNameProp.GetValue(null);
+            if (saveName == null)
+            {
+                saveName = (string)GetNextAvailableSaveNameMethod.Invoke(null, Array.Empty<object>());
+                ActiveSaveSlotNameProp.SetValue(null, saveName);
+            }
+
+            if (overwrite)
+            {
+                Campaign.Current.SaveHandler.SaveAs(saveName);
+            }
+            else
+            {
+                Campaign.Current.SaveHandler.SaveAs(saveName + new TextObject("{=player_settlement_n_02} (auto)").ToString());
+            }
+        }
+
+        private void ApplyInternal(
+            SaveMechanism saveMechanism,
+            string originalSaveName,
+            bool isSaveSuccessful,
+            string newSaveGameName,
+            Action<SaveMechanism, string>? afterSave = null)
+        {
+            CampaignEvents.OnSaveOverEvent.ClearListeners(this);
+
+            if (!isSaveSuccessful)
+            {
+                ResetPendingState();
+                return;
+            }
+
+            try
+            {
+                afterSave?.Invoke(saveMechanism, newSaveGameName);
+            }
+            catch
+            {
+            }
+
+            _deferredSaveMechanism = saveMechanism;
+            _deferredOriginalSaveName = originalSaveName;
+            _deferredNewSaveGameName = newSaveGameName;
+            _deferredLoadTicks = 3;
+            _deferredLoadPending = true;
+
+            CampaignEvents.TickEvent.ClearListeners(this);
+            CampaignEvents.TickEvent.AddNonSerializedListener(this, OnDeferredLoadTick);
+        }
+
+        private void OnDeferredLoadTick(float dt)
+        {
+            if (!_deferredLoadPending)
+            {
+                CampaignEvents.TickEvent.ClearListeners(this);
+                return;
+            }
+
+            if (_deferredLoadTicks-- > 0)
+            {
+                return;
+            }
+
+            CampaignEvents.TickEvent.ClearListeners(this);
+
+            SaveMechanism saveMechanism = _deferredSaveMechanism;
+            string originalSaveName = _deferredOriginalSaveName ?? string.Empty;
+            string newSaveGameName = _deferredNewSaveGameName ?? string.Empty;
+
+            _deferredLoadPending = false;
+            _deferredOriginalSaveName = null;
+            _deferredNewSaveGameName = null;
+
+            BeginDeferredLoad(saveMechanism, originalSaveName, newSaveGameName);
+        }
+
+        private void BeginDeferredLoad(SaveMechanism saveMechanism, string originalSaveName, string newSaveGameName)
+        {
+            SaveGameFileInfo saveFileWithName = MBSaveLoad.GetSaveFileWithName(newSaveGameName);
+            if (saveFileWithName != null && !saveFileWithName.IsCorrupted)
+            {
+                SandBoxSaveHelper.TryLoadSave(saveFileWithName, new Action<LoadResult>(loadResult =>
+                {
+                    if (saveMechanism == SaveMechanism.Temporary)
+                    {
+                        MBSaveLoad.DeleteSaveGame(newSaveGameName);
+                        SaveGameFileInfo originalSave = MBSaveLoad.GetSaveFileWithName(originalSaveName);
+                        if (originalSave != null && !originalSave.IsCorrupted)
+                        {
+                            ActiveSaveSlotNameProp.SetValue(null, originalSaveName);
+                        }
+                    }
+
+                    _saveLoadInProgress = false;
+                    StartGame(loadResult);
+                }), ResetPendingState);
+                return;
+            }
+
+            ResetPendingState();
+            InformationManager.ShowInquiry(new InquiryData(
+                new TextObject("{=oZrVNUOk}Error").ToString(),
+                new TextObject("{=t6W3UjG0}Save game file appear to be corrupted. Try starting a new campaign or load another one from Saved Games menu.").ToString(),
+                true,
+                false,
+                new TextObject("{=yS7PvrTD}OK").ToString(),
+                null,
+                null,
+                null,
+                "",
+                0f,
+                null,
+                null,
+                null), false, false);
+        }
+
+        private void ResetPendingState()
+        {
+            CampaignEvents.OnSaveOverEvent.ClearListeners(this);
+            CampaignEvents.TickEvent.ClearListeners(this);
+            _saveLoadInProgress = false;
+            _deferredLoadPending = false;
+            _deferredLoadTicks = 0;
+            _deferredOriginalSaveName = null;
+            _deferredNewSaveGameName = null;
+        }
+
+        public void StartGame(LoadResult loadResult)
+        {
+            if (Game.Current != null)
+            {
+                GameStateManager.Current.CleanStates(0);
+                GameStateManager.Current = TaleWorlds.MountAndBlade.Module.CurrentModule.GlobalGameStateManager;
+            }
+
+            MBSaveLoad.OnStartGame(loadResult);
+            MBGameManager.StartNewGame(new SandBoxGameManager(loadResult));
+        }
+    }
+}

--- a/_temp_player_settlement_v755/build.ps1
+++ b/_temp_player_settlement_v755/build.ps1
@@ -1,0 +1,54 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Join-Path $env:GITHUB_WORKSPACE '_player_settlement_v755_build'
+$src = Join-Path $root 'source'
+$out = Join-Path $root 'out'
+New-Item -ItemType Directory -Force -Path $root,$out | Out-Null
+
+$expectedCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
+git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src
+if ($LASTEXITCODE -ne 0) { throw "git clone failed: $LASTEXITCODE" }
+git -C $src checkout $expectedCommit
+if ($LASTEXITCODE -ne 0) { throw "git checkout failed: $LASTEXITCODE" }
+
+$nativeArtifact = Join-Path $env:GITHUB_WORKSPACE '_downloaded_native'
+$nativePatch = Get-ChildItem $nativeArtifact -Recurse -Filter 'source.patch' | Select-Object -First 1
+if (-not $nativePatch) { throw '7.5.4 native-visual source.patch not found' }
+
+git -C $src apply $nativePatch.FullName
+if ($LASTEXITCODE -ne 0) { throw "native-visual patch failed: $LASTEXITCODE" }
+
+Copy-Item (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v755\SaveHandler.cs') (Join-Path $src 'BannerlordPlayerSettlement\SaveHandler.cs') -Force
+
+$project = Join-Path $src 'BannerlordPlayerSettlement\BannerlordPlayerSettlement.csproj'
+$projectText = Get-Content -Raw $project
+$projectText = $projectText.Replace('<Version>7.5.4</Version>', '<Version>7.5.5</Version>')
+Set-Content -Encoding UTF8 $project $projectText
+
+git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source.patch')
+
+& dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
+if ($LASTEXITCODE -ne 0) {
+    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 200 | ForEach-Object { Write-Host $_ }
+    throw "dotnet build failed: $LASTEXITCODE"
+}
+
+$built = Get-ChildItem (Join-Path $src 'BannerlordPlayerSettlement\bin') -Recurse -Filter 'PlayerSettlement.dll' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
+$builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
+Copy-Item $built.FullName (Join-Path $out 'PlayerSettlement.dll') -Force
+if (Test-Path $builtPdb) { Copy-Item $builtPdb (Join-Path $out 'PlayerSettlement.pdb') -Force }
+
+$version = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
+if ($version -ne '7.5.5.0') { throw "Unexpected assembly version: $version" }
+
+$dllHash = (Get-FileHash $built.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+@"
+AssemblyVersion=$version
+DLL_SHA256=$dllHash
+UpstreamCommit=$expectedCommit
+Fixes=deferred OnSaveOver reload; no live MapScreen PopScreen
+"@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO.txt')
+
+Write-Host "PlayerSettlement.dll version: $version"
+Write-Host "SHA256: $dllHash"


### PR DESCRIPTION
Temporary CI-only build completed successfully. Player Settlement 7.5.5.0 was compiled with deferred post-save reload and removal of the invalid live MapScreen PopScreen call. No MapPerfFix changes were merged.