### PR TITLE
Temporary Player Settlement 7.5.8 army-state build

### DIFF
--- a/.github/workflows/temp-player-settlement-v758.yml
+++ b/.github/workflows/temp-player-settlement-v758.yml
@@ -1,0 +1,40 @@
+name: Temporary Player Settlement 7.5.8 build
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_temp_player_settlement_v758/**'
+      - '.github/workflows/temp-player-settlement-v758.yml'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download validated 7.5.4 native-visual build inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: player-settlement-native-visuals
+          path: _downloaded_native
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: xmarre/MapPerfFix
+          run-id: 29352502369
+
+      - name: Build Player Settlement 7.5.8
+        shell: pwsh
+        run: ./_temp_player_settlement_v758/build.ps1
+
+      - name: Upload DLL and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-settlement-v758-army-attachment-fix
+          path: _player_settlement_v758_build/out
+          if-no-files-found: error

--- a/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
+++ b/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+
+using HarmonyLib;
+
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace BannerlordPlayerSettlement.Patches
+{
+    /// <summary>
+    /// Bannerlord 1.3.15 assumes that a non-null MainParty.AttachedTo always has a valid Army,
+    /// and that the player's party has already restored the same Army. A save/reload can restore
+    /// these references over separate load phases. The vanilla OnTick dereferences the incomplete
+    /// chain without null checks.
+    /// </summary>
+    [HarmonyPatch(typeof(PlayerArmyWaitBehavior), "OnTick")]
+    internal static class PlayerArmyWaitBehaviorOnTickSafetyPatch
+    {
+        private static bool _reportedCurrentEpisode;
+
+        [HarmonyPrefix]
+        private static bool Prefix()
+        {
+            try
+            {
+                MobileParty? mainParty = MobileParty.MainParty;
+                if (mainParty == null)
+                {
+                    return false;
+                }
+
+                MobileParty? attachedTo = mainParty.AttachedTo;
+                if (attachedTo == null)
+                {
+                    _reportedCurrentEpisode = false;
+                    return true;
+                }
+
+                Army? attachedArmy = attachedTo.Army;
+                Army? mainArmy = mainParty.Army;
+                MobileParty? heroParty = Hero.MainHero?.PartyBelongedTo;
+                Army? heroArmy = heroParty?.Army;
+
+                bool staleAttachment = attachedArmy == null ||
+                                       mainArmy == null ||
+                                       !ReferenceEquals(attachedArmy, mainArmy);
+
+                if (staleAttachment)
+                {
+                    LogOnce($"Repairing stale army attachment: attachedArmy={(attachedArmy == null ? "null" : "set")}, mainArmy={(mainArmy == null ? "null" : "set")}");
+
+                    // Use Bannerlord's public setter so it removes the party from AttachedParties,
+                    // clears associated event/siege state and resets movement normally.
+                    mainParty.AttachedTo = null;
+
+                    // An orphaned or mismatched Army must also be left through its public setter.
+                    if (mainParty.Army != null &&
+                        (attachedArmy == null ||
+                         !ReferenceEquals(mainParty.Army, attachedArmy) ||
+                         mainParty.Army.LeaderParty == null))
+                    {
+                        mainParty.Army = null;
+                    }
+
+                    return false;
+                }
+
+                // The core attachment agrees, but some load-time references may still be filled
+                // on a later tick. Skip the unsafe vanilla method without altering valid state.
+                if (attachedArmy.LeaderParty == null ||
+                    heroParty == null ||
+                    heroArmy == null ||
+                    heroArmy.LeaderParty == null)
+                {
+                    LogOnce("Deferring PlayerArmyWaitBehavior until army references finish loading");
+                    return false;
+                }
+
+                _reportedCurrentEpisode = false;
+                return true;
+            }
+            catch (Exception e)
+            {
+                LogOnce("Suppressed PlayerArmyWaitBehavior state exception: " + e);
+                return false;
+            }
+        }
+
+        private static void LogOnce(string message)
+        {
+            if (_reportedCurrentEpisode)
+            {
+                return;
+            }
+
+            _reportedCurrentEpisode = true;
+            try
+            {
+                string userDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                    "Mount and Blade II Bannerlord");
+                string directory = Path.Combine(userDir, "Configs", "BannerlordPlayerSettlement");
+                Directory.CreateDirectory(directory);
+                File.AppendAllText(
+                    Path.Combine(directory, "army_attachment_repair.log"),
+                    DateTime.UtcNow.ToString("O") + " | " + message + Environment.NewLine);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
+++ b/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
@@ -43,6 +43,8 @@ namespace BannerlordPlayerSettlement.Patches
                     return true;
                 }
 
+                // The original method only dereferences AttachedTo.Army when this menu is active.
+                // Do not interfere with unrelated campaign ticks.
                 string? menuId = campaign.CurrentMenuContext?.GameMenu?.StringId;
                 if (!string.Equals(menuId, "army_wait", StringComparison.Ordinal))
                 {

--- a/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
+++ b/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
@@ -10,23 +10,28 @@ using TaleWorlds.CampaignSystem.Party;
 namespace BannerlordPlayerSettlement.Patches
 {
     /// <summary>
-    /// Bannerlord 1.3.15 assumes that a non-null MainParty.AttachedTo always has a valid Army,
-    /// and that the player's party has already restored the same Army. A save/reload can restore
-    /// these references over separate load phases. The vanilla OnTick dereferences the incomplete
-    /// chain without null checks.
+    /// Bannerlord 1.3.15 assumes that, while the army-wait menu is active, a non-null
+    /// MainParty.AttachedTo already has a fully restored Army chain. The automatic
+    /// post-placement reload can expose that chain over separate load phases. The vanilla
+    /// method dereferences it without null or consistency checks.
+    ///
+    /// This prefix is deliberately non-destructive: it only suppresses the vanilla tick
+    /// while the exact reference chain it needs is incomplete. It does not detach the
+    /// player or make the player leave an army.
     /// </summary>
     [HarmonyPatch(typeof(PlayerArmyWaitBehavior), "OnTick")]
     internal static class PlayerArmyWaitBehaviorOnTickSafetyPatch
     {
-        private static bool _reportedCurrentEpisode;
+        private static string? _lastEpisodeSignature;
 
         [HarmonyPrefix]
         private static bool Prefix()
         {
             try
             {
+                Campaign? campaign = Campaign.Current;
                 MobileParty? mainParty = MobileParty.MainParty;
-                if (mainParty == null)
+                if (campaign == null || mainParty == null)
                 {
                     return false;
                 }
@@ -34,7 +39,16 @@ namespace BannerlordPlayerSettlement.Patches
                 MobileParty? attachedTo = mainParty.AttachedTo;
                 if (attachedTo == null)
                 {
-                    _reportedCurrentEpisode = false;
+                    _lastEpisodeSignature = null;
+                    return true;
+                }
+
+                // The original method only dereferences AttachedTo.Army when this menu is active.
+                // Do not interfere with unrelated campaign ticks.
+                string? menuId = campaign.CurrentMenuContext?.GameMenu?.StringId;
+                if (!string.Equals(menuId, "army_wait", StringComparison.Ordinal))
+                {
+                    _lastEpisodeSignature = null;
                     return true;
                 }
 
@@ -43,59 +57,55 @@ namespace BannerlordPlayerSettlement.Patches
                 MobileParty? heroParty = Hero.MainHero?.PartyBelongedTo;
                 Army? heroArmy = heroParty?.Army;
 
-                bool staleAttachment = attachedArmy == null ||
-                                       mainArmy == null ||
-                                       !ReferenceEquals(attachedArmy, mainArmy);
+                bool completeAndConsistent = attachedArmy != null &&
+                                             mainArmy != null &&
+                                             heroParty != null &&
+                                             heroArmy != null &&
+                                             attachedArmy.LeaderParty != null &&
+                                             mainArmy.LeaderParty != null &&
+                                             heroArmy.LeaderParty != null &&
+                                             ReferenceEquals(attachedArmy, mainArmy) &&
+                                             ReferenceEquals(mainArmy, heroArmy);
 
-                if (staleAttachment)
+                if (!completeAndConsistent)
                 {
-                    LogOnce($"Repairing stale army attachment: attachedArmy={(attachedArmy == null ? "null" : "set")}, mainArmy={(mainArmy == null ? "null" : "set")}");
-
-                    // Use Bannerlord's public setter so it removes the party from AttachedParties,
-                    // clears associated event/siege state and resets movement normally.
-                    mainParty.AttachedTo = null;
-
-                    // An orphaned or mismatched Army must also be left through its public setter.
-                    if (mainParty.Army != null &&
-                        (attachedArmy == null ||
-                         !ReferenceEquals(mainParty.Army, attachedArmy) ||
-                         mainParty.Army.LeaderParty == null))
-                    {
-                        mainParty.Army = null;
-                    }
-
+                    string signature =
+                        $"attachedArmy={State(attachedArmy)}, mainArmy={State(mainArmy)}, " +
+                        $"heroParty={(heroParty == null ? "null" : "set")}, heroArmy={State(heroArmy)}, " +
+                        $"sameAttachedMain={ReferenceEquals(attachedArmy, mainArmy)}, " +
+                        $"sameMainHero={ReferenceEquals(mainArmy, heroArmy)}";
+                    LogEpisode(signature);
                     return false;
                 }
 
-                // The core attachment agrees, but some load-time references may still be filled
-                // on a later tick. Skip the unsafe vanilla method without altering valid state.
-                if (attachedArmy.LeaderParty == null ||
-                    heroParty == null ||
-                    heroArmy == null ||
-                    heroArmy.LeaderParty == null)
-                {
-                    LogOnce("Deferring PlayerArmyWaitBehavior until army references finish loading");
-                    return false;
-                }
-
-                _reportedCurrentEpisode = false;
+                _lastEpisodeSignature = null;
                 return true;
             }
             catch (Exception e)
             {
-                LogOnce("Suppressed PlayerArmyWaitBehavior state exception: " + e);
+                LogEpisode("suppressed exception: " + e);
                 return false;
             }
         }
 
-        private static void LogOnce(string message)
+        private static string State(Army? army)
         {
-            if (_reportedCurrentEpisode)
+            if (army == null)
+            {
+                return "null";
+            }
+
+            return army.LeaderParty == null ? "set/leader-null" : "set/leader-set";
+        }
+
+        private static void LogEpisode(string signature)
+        {
+            if (string.Equals(_lastEpisodeSignature, signature, StringComparison.Ordinal))
             {
                 return;
             }
 
-            _reportedCurrentEpisode = true;
+            _lastEpisodeSignature = signature;
             try
             {
                 string userDir = Path.Combine(
@@ -105,7 +115,9 @@ namespace BannerlordPlayerSettlement.Patches
                 Directory.CreateDirectory(directory);
                 File.AppendAllText(
                     Path.Combine(directory, "army_attachment_repair.log"),
-                    DateTime.UtcNow.ToString("O") + " | " + message + Environment.NewLine);
+                    DateTime.UtcNow.ToString("O") +
+                    " | Deferred unsafe PlayerArmyWaitBehavior tick: " +
+                    signature + Environment.NewLine);
             }
             catch
             {

--- a/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
+++ b/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
@@ -43,8 +43,6 @@ namespace BannerlordPlayerSettlement.Patches
                     return true;
                 }
 
-                // The original method only dereferences AttachedTo.Army when this menu is active.
-                // Do not interfere with unrelated campaign ticks.
                 string? menuId = campaign.CurrentMenuContext?.GameMenu?.StringId;
                 if (!string.Equals(menuId, "army_wait", StringComparison.Ordinal))
                 {

--- a/_temp_player_settlement_v758/build.ps1
+++ b/_temp_player_settlement_v758/build.ps1
@@ -44,11 +44,15 @@ $projectText = Get-Content -Raw $project
 $projectText = $projectText.Replace('<Version>7.5.4</Version>', '<Version>7.5.8</Version>')
 Set-Content -Encoding UTF8 $project $projectText
 
+$armyPatchPath = Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs'
 if (-not (Select-String -Path $saveHandlerPath -SimpleMatch 'Clearing completed placement state before save')) { throw '7.5.7 placement reset missing' }
 if (-not (Select-String -Path (Join-Path $patchDir 'LifecycleSafetyPatches.cs') -SimpleMatch 'IsAnyInquiryActive')) { throw '7.5.7 inquiry guard missing' }
-if (-not (Select-String -Path (Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs') -SimpleMatch 'mainParty.AttachedTo = null')) { throw 'Army attachment repair missing' }
+if (-not (Select-String -Path $armyPatchPath -SimpleMatch 'completeAndConsistent')) { throw 'Army wait consistency guard missing' }
+if (Select-String -Path $armyPatchPath -SimpleMatch 'mainParty.AttachedTo = null') { throw 'Army wait guard must not detach the player' }
+if (Select-String -Path $armyPatchPath -SimpleMatch 'mainParty.Army = null') { throw 'Army wait guard must not remove the player from an army' }
 
 git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source.patch')
+Copy-Item $armyPatchPath (Join-Path $out 'PlayerArmyWaitSafetyPatch.cs') -Force
 
 & dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
 if ($LASTEXITCODE -ne 0) {
@@ -72,7 +76,7 @@ DLL_SHA256=$dllHash
 UpstreamCommit=$expectedCommit
 ReloadLifecycleBase=$reloadCommit
 PlacementStateBase=$v757Commit
-Fixes=repair stale MainParty AttachedTo/Army chain; defer transiently incomplete PlayerArmyWaitBehavior state
+Fixes=non-destructive, menu-specific PlayerArmyWaitBehavior consistency guard during post-placement reload
 "@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO.txt')
 
 Write-Host "PlayerSettlement.dll version: $version"

--- a/_temp_player_settlement_v758/build.ps1
+++ b/_temp_player_settlement_v758/build.ps1
@@ -1,0 +1,79 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Join-Path $env:GITHUB_WORKSPACE '_player_settlement_v758_build'
+$src = Join-Path $root 'source'
+$out = Join-Path $root 'out'
+New-Item -ItemType Directory -Force -Path $root,$out | Out-Null
+
+$expectedCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
+$reloadCommit = 'fce517b787dbb83edb2cf2c3224b12588b8064f5'
+$v757Commit = 'e437560ef05bdd8294f794be104e7413f4d1898f'
+
+git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src
+if ($LASTEXITCODE -ne 0) { throw "git clone failed: $LASTEXITCODE" }
+git -C $src checkout $expectedCommit
+if ($LASTEXITCODE -ne 0) { throw "git checkout failed: $LASTEXITCODE" }
+
+$nativeArtifact = Join-Path $env:GITHUB_WORKSPACE '_downloaded_native'
+$nativePatch = Get-ChildItem $nativeArtifact -Recurse -Filter 'source.patch' | Select-Object -First 1
+if (-not $nativePatch) { throw '7.5.4 native-visual source.patch not found' }
+
+git -C $src apply $nativePatch.FullName
+if ($LASTEXITCODE -ne 0) { throw "native-visual patch failed: $LASTEXITCODE" }
+
+$saveHandlerPath = Join-Path $src 'BannerlordPlayerSettlement\SaveHandler.cs'
+$mainPath = Join-Path $src 'BannerlordPlayerSettlement\Main.cs'
+$patchDir = Join-Path $src 'BannerlordPlayerSettlement\Patches'
+$mainPatchScript = Join-Path $root 'patch_main_v756.py'
+$v757SavePatchScript = Join-Path $root 'patch_save_handler_v757.py'
+
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/SaveHandler.cs" -OutFile $saveHandlerPath
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/patch_main_v756.py" -OutFile $mainPatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/patch_save_handler_v757.py" -OutFile $v757SavePatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/LifecycleSafetyPatches.cs" -OutFile (Join-Path $patchDir 'LifecycleSafetyPatches.cs')
+
+python $mainPatchScript $mainPath
+if ($LASTEXITCODE -ne 0) { throw "Main.cs lifecycle patch failed: $LASTEXITCODE" }
+python $v757SavePatchScript $saveHandlerPath
+if ($LASTEXITCODE -ne 0) { throw "SaveHandler.cs placement reset patch failed: $LASTEXITCODE" }
+
+Copy-Item (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v758\PlayerArmyWaitSafetyPatch.cs') (Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs') -Force
+
+$project = Join-Path $src 'BannerlordPlayerSettlement\BannerlordPlayerSettlement.csproj'
+$projectText = Get-Content -Raw $project
+$projectText = $projectText.Replace('<Version>7.5.4</Version>', '<Version>7.5.8</Version>')
+Set-Content -Encoding UTF8 $project $projectText
+
+if (-not (Select-String -Path $saveHandlerPath -SimpleMatch 'Clearing completed placement state before save')) { throw '7.5.7 placement reset missing' }
+if (-not (Select-String -Path (Join-Path $patchDir 'LifecycleSafetyPatches.cs') -SimpleMatch 'IsAnyInquiryActive')) { throw '7.5.7 inquiry guard missing' }
+if (-not (Select-String -Path (Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs') -SimpleMatch 'mainParty.AttachedTo = null')) { throw 'Army attachment repair missing' }
+
+git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source.patch')
+
+& dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
+if ($LASTEXITCODE -ne 0) {
+    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 280 | ForEach-Object { Write-Host $_ }
+    throw "dotnet build failed: $LASTEXITCODE"
+}
+
+$built = Get-ChildItem (Join-Path $src 'BannerlordPlayerSettlement\bin') -Recurse -Filter 'PlayerSettlement.dll' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
+$builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
+Copy-Item $built.FullName (Join-Path $out 'PlayerSettlement.dll') -Force
+if (Test-Path $builtPdb) { Copy-Item $builtPdb (Join-Path $out 'PlayerSettlement.pdb') -Force }
+
+$version = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
+if ($version -ne '7.5.8.0') { throw "Unexpected assembly version: $version" }
+
+$dllHash = (Get-FileHash $built.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+@"
+AssemblyVersion=$version
+DLL_SHA256=$dllHash
+UpstreamCommit=$expectedCommit
+ReloadLifecycleBase=$reloadCommit
+PlacementStateBase=$v757Commit
+Fixes=repair stale MainParty AttachedTo/Army chain; defer transiently incomplete PlayerArmyWaitBehavior state
+"@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO.txt')
+
+Write-Host "PlayerSettlement.dll version: $version"
+Write-Host "SHA256: $dllHash"


### PR DESCRIPTION
Temporary CI-only build completed successfully. Player Settlement 7.5.8.0 was compiled with a non-destructive, menu-specific PlayerArmyWaitBehavior consistency guard. It suppresses only the unsafe vanilla army-wait tick while post-reload army references are incomplete; it does not detach the player or alter army membership. No MapPerfFix changes were merged.