### PR TITLE
Temporary Player Settlement 7.5.9 global tick and gate build

### DIFF
--- a/.github/workflows/temp-player-settlement-v758.yml
+++ b/.github/workflows/temp-player-settlement-v758.yml
@@ -1,0 +1,40 @@
+name: Temporary Player Settlement 7.5.8 build
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_temp_player_settlement_v758/**'
+      - '.github/workflows/temp-player-settlement-v758.yml'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download validated 7.5.4 native-visual build inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: player-settlement-native-visuals
+          path: _downloaded_native
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: xmarre/MapPerfFix
+          run-id: 29352502369
+
+      - name: Build Player Settlement 7.5.8
+        shell: pwsh
+        run: ./_temp_player_settlement_v758/build.ps1
+
+      - name: Upload DLL and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-settlement-v758-army-attachment-fix
+          path: _player_settlement_v758_build/out
+          if-no-files-found: error

--- a/.github/workflows/temp-player-settlement-v759.yml
+++ b/.github/workflows/temp-player-settlement-v759.yml
@@ -1,0 +1,40 @@
+name: Temporary Player Settlement 7.5.9 build
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_temp_player_settlement_v759/**'
+      - '.github/workflows/temp-player-settlement-v759.yml'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download validated 7.5.4 native-visual build inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: player-settlement-native-visuals
+          path: _downloaded_native
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: xmarre/MapPerfFix
+          run-id: 29352502369
+
+      - name: Build Player Settlement 7.5.9
+        shell: pwsh
+        run: ./_temp_player_settlement_v759/build.ps1
+
+      - name: Upload DLL and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-settlement-v759-global-tick-gate-fix
+          path: _player_settlement_v759_build/out
+          if-no-files-found: error

--- a/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
+++ b/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+
+using HarmonyLib;
+
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace BannerlordPlayerSettlement.Patches
+{
+    /// <summary>
+    /// Bannerlord 1.3.15 assumes that a non-null MainParty.AttachedTo always has a valid Army,
+    /// and that the player's party has already restored the same Army. A save/reload can restore
+    /// these references over separate load phases. The vanilla OnTick dereferences the incomplete
+    /// chain without null checks.
+    /// </summary>
+    [HarmonyPatch(typeof(PlayerArmyWaitBehavior), "OnTick")]
+    internal static class PlayerArmyWaitBehaviorOnTickSafetyPatch
+    {
+        private static bool _reportedCurrentEpisode;
+
+        [HarmonyPrefix]
+        private static bool Prefix()
+        {
+            try
+            {
+                MobileParty? mainParty = MobileParty.MainParty;
+                if (mainParty == null)
+                {
+                    return false;
+                }
+
+                MobileParty? attachedTo = mainParty.AttachedTo;
+                if (attachedTo == null)
+                {
+                    _reportedCurrentEpisode = false;
+                    return true;
+                }
+
+                Army? attachedArmy = attachedTo.Army;
+                Army? mainArmy = mainParty.Army;
+                MobileParty? heroParty = Hero.MainHero?.PartyBelongedTo;
+                Army? heroArmy = heroParty?.Army;
+
+                bool staleAttachment = attachedArmy == null ||
+                                       mainArmy == null ||
+                                       !ReferenceEquals(attachedArmy, mainArmy);
+
+                if (staleAttachment)
+                {
+                    LogOnce($"Repairing stale army attachment: attachedArmy={(attachedArmy == null ? "null" : "set")}, mainArmy={(mainArmy == null ? "null" : "set")}");
+
+                    // Use Bannerlord's public setter so it removes the party from AttachedParties,
+                    // clears associated event/siege state and resets movement normally.
+                    mainParty.AttachedTo = null;
+
+                    // An orphaned or mismatched Army must also be left through its public setter.
+                    if (mainParty.Army != null &&
+                        (attachedArmy == null ||
+                         !ReferenceEquals(mainParty.Army, attachedArmy) ||
+                         mainParty.Army.LeaderParty == null))
+                    {
+                        mainParty.Army = null;
+                    }
+
+                    return false;
+                }
+
+                // The core attachment agrees, but some load-time references may still be filled
+                // on a later tick. Skip the unsafe vanilla method without altering valid state.
+                if (attachedArmy.LeaderParty == null ||
+                    heroParty == null ||
+                    heroArmy == null ||
+                    heroArmy.LeaderParty == null)
+                {
+                    LogOnce("Deferring PlayerArmyWaitBehavior until army references finish loading");
+                    return false;
+                }
+
+                _reportedCurrentEpisode = false;
+                return true;
+            }
+            catch (Exception e)
+            {
+                LogOnce("Suppressed PlayerArmyWaitBehavior state exception: " + e);
+                return false;
+            }
+        }
+
+        private static void LogOnce(string message)
+        {
+            if (_reportedCurrentEpisode)
+            {
+                return;
+            }
+
+            _reportedCurrentEpisode = true;
+            try
+            {
+                string userDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                    "Mount and Blade II Bannerlord");
+                string directory = Path.Combine(userDir, "Configs", "BannerlordPlayerSettlement");
+                Directory.CreateDirectory(directory);
+                File.AppendAllText(
+                    Path.Combine(directory, "army_attachment_repair.log"),
+                    DateTime.UtcNow.ToString("O") + " | " + message + Environment.NewLine);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
+++ b/_temp_player_settlement_v758/PlayerArmyWaitSafetyPatch.cs
@@ -10,23 +10,28 @@ using TaleWorlds.CampaignSystem.Party;
 namespace BannerlordPlayerSettlement.Patches
 {
     /// <summary>
-    /// Bannerlord 1.3.15 assumes that a non-null MainParty.AttachedTo always has a valid Army,
-    /// and that the player's party has already restored the same Army. A save/reload can restore
-    /// these references over separate load phases. The vanilla OnTick dereferences the incomplete
-    /// chain without null checks.
+    /// Bannerlord 1.3.15 assumes that, while the army-wait menu is active, a non-null
+    /// MainParty.AttachedTo already has a fully restored Army chain. The automatic
+    /// post-placement reload can expose that chain over separate load phases. The vanilla
+    /// method dereferences it without null or consistency checks.
+    ///
+    /// This prefix is deliberately non-destructive: it only suppresses the vanilla tick
+    /// while the exact reference chain it needs is incomplete. It does not detach the
+    /// player or make the player leave an army.
     /// </summary>
     [HarmonyPatch(typeof(PlayerArmyWaitBehavior), "OnTick")]
     internal static class PlayerArmyWaitBehaviorOnTickSafetyPatch
     {
-        private static bool _reportedCurrentEpisode;
+        private static string? _lastEpisodeSignature;
 
         [HarmonyPrefix]
         private static bool Prefix()
         {
             try
             {
+                Campaign? campaign = Campaign.Current;
                 MobileParty? mainParty = MobileParty.MainParty;
-                if (mainParty == null)
+                if (campaign == null || mainParty == null)
                 {
                     return false;
                 }
@@ -34,7 +39,16 @@ namespace BannerlordPlayerSettlement.Patches
                 MobileParty? attachedTo = mainParty.AttachedTo;
                 if (attachedTo == null)
                 {
-                    _reportedCurrentEpisode = false;
+                    _lastEpisodeSignature = null;
+                    return true;
+                }
+
+                // The original method only dereferences AttachedTo.Army when this menu is active.
+                // Do not interfere with unrelated campaign ticks.
+                string? menuId = campaign.CurrentMenuContext?.GameMenu?.StringId;
+                if (!string.Equals(menuId, "army_wait", StringComparison.Ordinal))
+                {
+                    _lastEpisodeSignature = null;
                     return true;
                 }
 
@@ -43,59 +57,55 @@ namespace BannerlordPlayerSettlement.Patches
                 MobileParty? heroParty = Hero.MainHero?.PartyBelongedTo;
                 Army? heroArmy = heroParty?.Army;
 
-                bool staleAttachment = attachedArmy == null ||
-                                       mainArmy == null ||
-                                       !ReferenceEquals(attachedArmy, mainArmy);
+                bool completeAndConsistent = attachedArmy != null &&
+                                             mainArmy != null &&
+                                             heroParty != null &&
+                                             heroArmy != null &&
+                                             attachedArmy.LeaderParty != null &&
+                                             mainArmy.LeaderParty != null &&
+                                             heroArmy.LeaderParty != null &&
+                                             ReferenceEquals(attachedArmy, mainArmy) &&
+                                             ReferenceEquals(mainArmy, heroArmy);
 
-                if (staleAttachment)
+                if (!completeAndConsistent)
                 {
-                    LogOnce($"Repairing stale army attachment: attachedArmy={(attachedArmy == null ? "null" : "set")}, mainArmy={(mainArmy == null ? "null" : "set")}");
-
-                    // Use Bannerlord's public setter so it removes the party from AttachedParties,
-                    // clears associated event/siege state and resets movement normally.
-                    mainParty.AttachedTo = null;
-
-                    // An orphaned or mismatched Army must also be left through its public setter.
-                    if (mainParty.Army != null &&
-                        (attachedArmy == null ||
-                         !ReferenceEquals(mainParty.Army, attachedArmy) ||
-                         mainParty.Army.LeaderParty == null))
-                    {
-                        mainParty.Army = null;
-                    }
-
+                    string signature =
+                        $"attachedArmy={State(attachedArmy)}, mainArmy={State(mainArmy)}, " +
+                        $"heroParty={(heroParty == null ? "null" : "set")}, heroArmy={State(heroArmy)}, " +
+                        $"sameAttachedMain={ReferenceEquals(attachedArmy, mainArmy)}, " +
+                        $"sameMainHero={ReferenceEquals(mainArmy, heroArmy)}";
+                    LogEpisode(signature);
                     return false;
                 }
 
-                // The core attachment agrees, but some load-time references may still be filled
-                // on a later tick. Skip the unsafe vanilla method without altering valid state.
-                if (attachedArmy.LeaderParty == null ||
-                    heroParty == null ||
-                    heroArmy == null ||
-                    heroArmy.LeaderParty == null)
-                {
-                    LogOnce("Deferring PlayerArmyWaitBehavior until army references finish loading");
-                    return false;
-                }
-
-                _reportedCurrentEpisode = false;
+                _lastEpisodeSignature = null;
                 return true;
             }
             catch (Exception e)
             {
-                LogOnce("Suppressed PlayerArmyWaitBehavior state exception: " + e);
+                LogEpisode("suppressed exception: " + e);
                 return false;
             }
         }
 
-        private static void LogOnce(string message)
+        private static string State(Army? army)
         {
-            if (_reportedCurrentEpisode)
+            if (army == null)
+            {
+                return "null";
+            }
+
+            return army.LeaderParty == null ? "set/leader-null" : "set/leader-set";
+        }
+
+        private static void LogEpisode(string signature)
+        {
+            if (string.Equals(_lastEpisodeSignature, signature, StringComparison.Ordinal))
             {
                 return;
             }
 
-            _reportedCurrentEpisode = true;
+            _lastEpisodeSignature = signature;
             try
             {
                 string userDir = Path.Combine(
@@ -105,7 +115,9 @@ namespace BannerlordPlayerSettlement.Patches
                 Directory.CreateDirectory(directory);
                 File.AppendAllText(
                     Path.Combine(directory, "army_attachment_repair.log"),
-                    DateTime.UtcNow.ToString("O") + " | " + message + Environment.NewLine);
+                    DateTime.UtcNow.ToString("O") +
+                    " | Deferred unsafe PlayerArmyWaitBehavior tick: " +
+                    signature + Environment.NewLine);
             }
             catch
             {

--- a/_temp_player_settlement_v758/build.ps1
+++ b/_temp_player_settlement_v758/build.ps1
@@ -44,11 +44,15 @@ $projectText = Get-Content -Raw $project
 $projectText = $projectText.Replace('<Version>7.5.4</Version>', '<Version>7.5.8</Version>')
 Set-Content -Encoding UTF8 $project $projectText
 
+$armyPatchPath = Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs'
 if (-not (Select-String -Path $saveHandlerPath -SimpleMatch 'Clearing completed placement state before save')) { throw '7.5.7 placement reset missing' }
 if (-not (Select-String -Path (Join-Path $patchDir 'LifecycleSafetyPatches.cs') -SimpleMatch 'IsAnyInquiryActive')) { throw '7.5.7 inquiry guard missing' }
-if (-not (Select-String -Path (Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs') -SimpleMatch 'mainParty.AttachedTo = null')) { throw 'Army attachment repair missing' }
+if (-not (Select-String -Path $armyPatchPath -SimpleMatch 'completeAndConsistent')) { throw 'Army wait consistency guard missing' }
+if (Select-String -Path $armyPatchPath -SimpleMatch 'mainParty.AttachedTo = null') { throw 'Army wait guard must not detach the player' }
+if (Select-String -Path $armyPatchPath -SimpleMatch 'mainParty.Army = null') { throw 'Army wait guard must not remove the player from an army' }
 
 git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source.patch')
+Copy-Item $armyPatchPath (Join-Path $out 'PlayerArmyWaitSafetyPatch.cs') -Force
 
 & dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
 if ($LASTEXITCODE -ne 0) {
@@ -72,7 +76,7 @@ DLL_SHA256=$dllHash
 UpstreamCommit=$expectedCommit
 ReloadLifecycleBase=$reloadCommit
 PlacementStateBase=$v757Commit
-Fixes=repair stale MainParty AttachedTo/Army chain; defer transiently incomplete PlayerArmyWaitBehavior state
+Fixes=non-destructive, menu-specific PlayerArmyWaitBehavior consistency guard during post-placement reload
 "@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO.txt')
 
 Write-Host "PlayerSettlement.dll version: $version"

--- a/_temp_player_settlement_v758/build.ps1
+++ b/_temp_player_settlement_v758/build.ps1
@@ -1,0 +1,79 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Join-Path $env:GITHUB_WORKSPACE '_player_settlement_v758_build'
+$src = Join-Path $root 'source'
+$out = Join-Path $root 'out'
+New-Item -ItemType Directory -Force -Path $root,$out | Out-Null
+
+$expectedCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
+$reloadCommit = 'fce517b787dbb83edb2cf2c3224b12588b8064f5'
+$v757Commit = 'e437560ef05bdd8294f794be104e7413f4d1898f'
+
+git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src
+if ($LASTEXITCODE -ne 0) { throw "git clone failed: $LASTEXITCODE" }
+git -C $src checkout $expectedCommit
+if ($LASTEXITCODE -ne 0) { throw "git checkout failed: $LASTEXITCODE" }
+
+$nativeArtifact = Join-Path $env:GITHUB_WORKSPACE '_downloaded_native'
+$nativePatch = Get-ChildItem $nativeArtifact -Recurse -Filter 'source.patch' | Select-Object -First 1
+if (-not $nativePatch) { throw '7.5.4 native-visual source.patch not found' }
+
+git -C $src apply $nativePatch.FullName
+if ($LASTEXITCODE -ne 0) { throw "native-visual patch failed: $LASTEXITCODE" }
+
+$saveHandlerPath = Join-Path $src 'BannerlordPlayerSettlement\SaveHandler.cs'
+$mainPath = Join-Path $src 'BannerlordPlayerSettlement\Main.cs'
+$patchDir = Join-Path $src 'BannerlordPlayerSettlement\Patches'
+$mainPatchScript = Join-Path $root 'patch_main_v756.py'
+$v757SavePatchScript = Join-Path $root 'patch_save_handler_v757.py'
+
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/SaveHandler.cs" -OutFile $saveHandlerPath
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/patch_main_v756.py" -OutFile $mainPatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/patch_save_handler_v757.py" -OutFile $v757SavePatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/LifecycleSafetyPatches.cs" -OutFile (Join-Path $patchDir 'LifecycleSafetyPatches.cs')
+
+python $mainPatchScript $mainPath
+if ($LASTEXITCODE -ne 0) { throw "Main.cs lifecycle patch failed: $LASTEXITCODE" }
+python $v757SavePatchScript $saveHandlerPath
+if ($LASTEXITCODE -ne 0) { throw "SaveHandler.cs placement reset patch failed: $LASTEXITCODE" }
+
+Copy-Item (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v758\PlayerArmyWaitSafetyPatch.cs') (Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs') -Force
+
+$project = Join-Path $src 'BannerlordPlayerSettlement\BannerlordPlayerSettlement.csproj'
+$projectText = Get-Content -Raw $project
+$projectText = $projectText.Replace('<Version>7.5.4</Version>', '<Version>7.5.8</Version>')
+Set-Content -Encoding UTF8 $project $projectText
+
+if (-not (Select-String -Path $saveHandlerPath -SimpleMatch 'Clearing completed placement state before save')) { throw '7.5.7 placement reset missing' }
+if (-not (Select-String -Path (Join-Path $patchDir 'LifecycleSafetyPatches.cs') -SimpleMatch 'IsAnyInquiryActive')) { throw '7.5.7 inquiry guard missing' }
+if (-not (Select-String -Path (Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs') -SimpleMatch 'mainParty.AttachedTo = null')) { throw 'Army attachment repair missing' }
+
+git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source.patch')
+
+& dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
+if ($LASTEXITCODE -ne 0) {
+    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 280 | ForEach-Object { Write-Host $_ }
+    throw "dotnet build failed: $LASTEXITCODE"
+}
+
+$built = Get-ChildItem (Join-Path $src 'BannerlordPlayerSettlement\bin') -Recurse -Filter 'PlayerSettlement.dll' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
+$builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
+Copy-Item $built.FullName (Join-Path $out 'PlayerSettlement.dll') -Force
+if (Test-Path $builtPdb) { Copy-Item $builtPdb (Join-Path $out 'PlayerSettlement.pdb') -Force }
+
+$version = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
+if ($version -ne '7.5.8.0') { throw "Unexpected assembly version: $version" }
+
+$dllHash = (Get-FileHash $built.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+@"
+AssemblyVersion=$version
+DLL_SHA256=$dllHash
+UpstreamCommit=$expectedCommit
+ReloadLifecycleBase=$reloadCommit
+PlacementStateBase=$v757Commit
+Fixes=repair stale MainParty AttachedTo/Army chain; defer transiently incomplete PlayerArmyWaitBehavior state
+"@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO.txt')
+
+Write-Host "PlayerSettlement.dll version: $version"
+Write-Host "SHA256: $dllHash"

--- a/_temp_player_settlement_v759/GlobalCampaignTickSafetyPatch.cs
+++ b/_temp_player_settlement_v759/GlobalCampaignTickSafetyPatch.cs
@@ -5,6 +5,7 @@ using HarmonyLib;
 
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Core;
 
 namespace BannerlordPlayerSettlement.Patches
 {

--- a/_temp_player_settlement_v759/GlobalCampaignTickSafetyPatch.cs
+++ b/_temp_player_settlement_v759/GlobalCampaignTickSafetyPatch.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+
+using HarmonyLib;
+
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace BannerlordPlayerSettlement.Patches
+{
+    /// <summary>
+    /// The automatic campaign reload can expose CampaignEvents.Tick before Bannerlord has
+    /// restored the main-party and army reference graph. Vanilla tick listeners assume those
+    /// globals are complete and throw from unrelated behaviors (food, army wait, etc.).
+    /// Block the entire TickEvent dispatch until the graph is coherent. If an attachment remains
+    /// provably stale for a sustained period, repair it through Bannerlord's public setters.
+    /// </summary>
+    [HarmonyPatch(typeof(CampaignEventDispatcher), nameof(CampaignEventDispatcher.Tick))]
+    internal static class CampaignEventDispatcherPostLoadSafetyPatch
+    {
+        private const int RepairAfterBlockedTicks = 120;
+        private static int _blockedTicks;
+        private static bool _reportedEpisode;
+
+        [HarmonyPrefix]
+        private static bool Prefix()
+        {
+            try
+            {
+                if (Campaign.Current == null || Game.Current == null)
+                {
+                    ResetEpisode();
+                    return true;
+                }
+
+                MobileParty? mainParty = MobileParty.MainParty;
+                Hero? mainHero = Hero.MainHero;
+                if (mainParty == null || mainHero == null || mainParty.Party == null)
+                {
+                    return Block("Waiting for main party and hero initialization");
+                }
+
+                PartyBase? partyBase;
+                try
+                {
+                    partyBase = PartyBase.MainParty;
+                }
+                catch (NullReferenceException)
+                {
+                    return Block("Waiting for PartyBase.MainParty initialization");
+                }
+
+                if (partyBase == null || !ReferenceEquals(partyBase, mainParty.Party))
+                {
+                    return Block("Waiting for main-party PartyBase linkage");
+                }
+
+                MobileParty? heroParty = mainHero.PartyBelongedTo;
+                if (heroParty == null || !ReferenceEquals(heroParty, mainParty))
+                {
+                    return Block("Waiting for hero/main-party linkage");
+                }
+
+                MobileParty? attachedTo = mainParty.AttachedTo;
+                Army? mainArmy = mainParty.Army;
+                Army? heroArmy = heroParty.Army;
+
+                if (attachedTo != null)
+                {
+                    Army? attachedArmy = attachedTo.Army;
+                    bool coherent = attachedArmy != null &&
+                                    mainArmy != null &&
+                                    heroArmy != null &&
+                                    ReferenceEquals(attachedArmy, mainArmy) &&
+                                    ReferenceEquals(heroArmy, mainArmy) &&
+                                    mainArmy.LeaderParty != null;
+
+                    if (!coherent)
+                    {
+                        if (++_blockedTicks < RepairAfterBlockedTicks)
+                        {
+                            LogOnce("Deferring campaign TickEvent while attached-army references finish loading");
+                            return false;
+                        }
+
+                        Log("Repairing stale attached-party/army state after reload");
+                        mainParty.AttachedTo = null;
+
+                        if (mainParty.Army != null &&
+                            (mainParty.Army.LeaderParty == null ||
+                             attachedArmy == null ||
+                             !ReferenceEquals(mainParty.Army, attachedArmy)))
+                        {
+                            mainParty.Army = null;
+                        }
+
+                        _blockedTicks = 0;
+                        return false;
+                    }
+                }
+                else if (mainArmy != null)
+                {
+                    bool coherent = mainArmy.LeaderParty != null && ReferenceEquals(heroArmy, mainArmy);
+                    if (!coherent)
+                    {
+                        if (++_blockedTicks < RepairAfterBlockedTicks)
+                        {
+                            LogOnce("Deferring campaign TickEvent while main-army references finish loading");
+                            return false;
+                        }
+
+                        Log("Clearing orphaned main-party army state after reload");
+                        mainParty.Army = null;
+                        _blockedTicks = 0;
+                        return false;
+                    }
+                }
+
+                ResetEpisode();
+                return true;
+            }
+            catch (Exception e)
+            {
+                LogOnce("Suppressed incomplete post-load campaign tick: " + e);
+                _blockedTicks++;
+                return false;
+            }
+        }
+
+        private static bool Block(string message)
+        {
+            _blockedTicks++;
+            LogOnce(message);
+            return false;
+        }
+
+        private static void ResetEpisode()
+        {
+            _blockedTicks = 0;
+            _reportedEpisode = false;
+        }
+
+        private static void LogOnce(string message)
+        {
+            if (_reportedEpisode)
+            {
+                return;
+            }
+
+            _reportedEpisode = true;
+            Log(message);
+        }
+
+        private static void Log(string message)
+        {
+            try
+            {
+                string userDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                    "Mount and Blade II Bannerlord");
+                string directory = Path.Combine(userDir, "Configs", "BannerlordPlayerSettlement");
+                Directory.CreateDirectory(directory);
+                File.AppendAllText(
+                    Path.Combine(directory, "post_load_tick_guard.log"),
+                    DateTime.UtcNow.ToString("O") + " | " + message + Environment.NewLine);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/_temp_player_settlement_v759/build.ps1
+++ b/_temp_player_settlement_v759/build.ps1
@@ -1,0 +1,90 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Join-Path $env:GITHUB_WORKSPACE '_player_settlement_v759_build'
+$src = Join-Path $root 'source'
+$out = Join-Path $root 'out'
+New-Item -ItemType Directory -Force -Path $root,$out | Out-Null
+
+$expectedCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
+$reloadCommit = 'fce517b787dbb83edb2cf2c3224b12588b8064f5'
+$v757Commit = 'e437560ef05bdd8294f794be104e7413f4d1898f'
+
+git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src
+if ($LASTEXITCODE -ne 0) { throw "git clone failed: $LASTEXITCODE" }
+git -C $src checkout $expectedCommit
+if ($LASTEXITCODE -ne 0) { throw "git checkout failed: $LASTEXITCODE" }
+
+$nativeArtifact = Join-Path $env:GITHUB_WORKSPACE '_downloaded_native'
+$nativePatch = Get-ChildItem $nativeArtifact -Recurse -Filter 'source.patch' | Select-Object -First 1
+if (-not $nativePatch) { throw '7.5.4 native-visual source.patch not found' }
+
+git -C $src apply $nativePatch.FullName
+if ($LASTEXITCODE -ne 0) { throw "native-visual patch failed: $LASTEXITCODE" }
+
+$behaviourPath = Join-Path $src 'BannerlordPlayerSettlement\Behaviours\PlayerSettlementBehaviour.cs'
+$saveHandlerPath = Join-Path $src 'BannerlordPlayerSettlement\SaveHandler.cs'
+$mainPath = Join-Path $src 'BannerlordPlayerSettlement\Main.cs'
+$patchDir = Join-Path $src 'BannerlordPlayerSettlement\Patches'
+$mainPatchScript = Join-Path $root 'patch_main_v756.py'
+$v757SavePatchScript = Join-Path $root 'patch_save_handler_v757.py'
+
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/SaveHandler.cs" -OutFile $saveHandlerPath
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/patch_main_v756.py" -OutFile $mainPatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/patch_save_handler_v757.py" -OutFile $v757SavePatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/LifecycleSafetyPatches.cs" -OutFile (Join-Path $patchDir 'LifecycleSafetyPatches.cs')
+
+python $mainPatchScript $mainPath
+if ($LASTEXITCODE -ne 0) { throw "Main.cs lifecycle patch failed: $LASTEXITCODE" }
+python $v757SavePatchScript $saveHandlerPath
+if ($LASTEXITCODE -ne 0) { throw "SaveHandler.cs placement reset patch failed: $LASTEXITCODE" }
+python (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v759\patch_gate_workflow_v759.py') $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "Gate workflow patch failed: $LASTEXITCODE" }
+
+Copy-Item (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v759\GlobalCampaignTickSafetyPatch.cs') (Join-Path $patchDir 'GlobalCampaignTickSafetyPatch.cs') -Force
+
+$project = Join-Path $src 'BannerlordPlayerSettlement\BannerlordPlayerSettlement.csproj'
+$projectText = Get-Content -Raw $project
+$projectText = $projectText.Replace('<Version>7.5.4</Version>', '<Version>7.5.9</Version>')
+Set-Content -Encoding UTF8 $project $projectText
+
+$globalPatchPath = Join-Path $patchDir 'GlobalCampaignTickSafetyPatch.cs'
+if (-not (Select-String -Path $saveHandlerPath -SimpleMatch 'Clearing completed placement state before save')) { throw '7.5.7 placement reset missing' }
+if (-not (Select-String -Path (Join-Path $patchDir 'LifecycleSafetyPatches.cs') -SimpleMatch 'IsAnyInquiryActive')) { throw '7.5.7 inquiry guard missing' }
+if (-not (Select-String -Path $globalPatchPath -SimpleMatch 'CampaignEventDispatcherPostLoadSafetyPatch')) { throw 'Global campaign tick guard missing' }
+if (-not (Select-String -Path $globalPatchPath -SimpleMatch 'RepairAfterBlockedTicks')) { throw 'Sustained stale-state repair missing' }
+if (-not (Select-String -Path $behaviourPath -SimpleMatch 'ShowGatePosHelp(forceShow: true)')) { throw 'Forced gate phase help missing' }
+if (-not (Select-String -Path $behaviourPath -SimpleMatch 'gatePlacementActive')) { throw 'Explicit gate phase state missing' }
+if (-not (Select-String -Path $behaviourPath -SimpleMatch 'cursor-only placement')) { throw 'Marker-free gate fallback missing' }
+
+git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source.patch')
+Copy-Item $globalPatchPath (Join-Path $out 'GlobalCampaignTickSafetyPatch.cs') -Force
+Copy-Item $behaviourPath (Join-Path $out 'PlayerSettlementBehaviour.cs') -Force
+Copy-Item $saveHandlerPath (Join-Path $out 'SaveHandler.cs') -Force
+
+& dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
+if ($LASTEXITCODE -ne 0) {
+    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 320 | ForEach-Object { Write-Host $_ }
+    throw "dotnet build failed: $LASTEXITCODE"
+}
+
+$built = Get-ChildItem (Join-Path $src 'BannerlordPlayerSettlement\bin') -Recurse -Filter 'PlayerSettlement.dll' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
+$builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
+Copy-Item $built.FullName (Join-Path $out 'PlayerSettlement.dll') -Force
+if (Test-Path $builtPdb) { Copy-Item $builtPdb (Join-Path $out 'PlayerSettlement.pdb') -Force }
+
+$version = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
+if ($version -ne '7.5.9.0') { throw "Unexpected assembly version: $version" }
+
+$dllHash = (Get-FileHash $built.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+@"
+AssemblyVersion=$version
+DLL_SHA256=$dllHash
+UpstreamCommit=$expectedCommit
+ReloadLifecycleBase=$reloadCommit
+PlacementStateBase=$v757Commit
+Fixes=global TickEvent readiness guard with delayed stale army repair; explicit gate/port phases; forced phase instructions; cursor-only marker fallback; fixed no-port callback
+"@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO.txt')
+
+Write-Host "PlayerSettlement.dll version: $version"
+Write-Host "SHA256: $dllHash"

--- a/_temp_player_settlement_v759/patch_gate_workflow_v759.py
+++ b/_temp_player_settlement_v759/patch_gate_workflow_v759.py
@@ -1,0 +1,198 @@
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8-sig")
+
+
+def replace_once(old: str, new: str, name: str) -> None:
+    global source
+    if old not in source:
+        raise RuntimeError(f"marker not found for {name}")
+    source = source.replace(old, new, 1)
+
+replace_once(
+'''        bool gateSupported = false;
+        bool portSupported = false;
+        #endregion
+
+        public bool IsPlacingSettlement => settlementVisualEntity != null && applyPending != null;
+        public bool IsDeepEdit => deepEdit && currentDeepTarget != null && IsPlacingSettlement && !IsPlacingGate && !IsPlacingPort;
+        public bool IsPlacingGate => ghostGateVisualEntity != null && applyPending != null;
+        public bool IsPlacingPort => ghostPortVisualEntity != null && applyPending != null;''',
+'''        bool gateSupported = false;
+        bool portSupported = false;
+        private bool gatePlacementActive = false;
+        private bool portPlacementActive = false;
+        #endregion
+
+        public bool IsPlacingSettlement => settlementVisualEntity != null && applyPending != null && !gatePlacementActive && !portPlacementActive;
+        public bool IsDeepEdit => deepEdit && currentDeepTarget != null && IsPlacingSettlement && !IsPlacingGate && !IsPlacingPort;
+        public bool IsPlacingGate => gatePlacementActive && applyPending != null;
+        public bool IsPlacingPort => portPlacementActive && applyPending != null;''',
+"placement phase fields")
+
+replace_once(
+'''        public void RefreshVisualSelection()
+        {
+            deepEditScale = 1f;
+            currentDeepTarget = null;
+
+            currentModelOptionIdx -= 1;''',
+'''        public void RefreshVisualSelection()
+        {
+            gatePlacementActive = false;
+            portPlacementActive = false;
+            ghostGateVisualEntity?.ClearEntity();
+            ghostGateVisualEntity = null;
+            ghostPortVisualEntity?.ClearEntity();
+            ghostPortVisualEntity = null;
+            gatePlacementFrame = null;
+            portPlacementFrame = null;
+
+            deepEditScale = 1f;
+            currentDeepTarget = null;
+
+            currentModelOptionIdx -= 1;''',
+"refresh phase reset")
+
+replace_once(
+'''        public void StartPortPlacement()
+        {
+            // Ensure no previous port frame gets used. If a port was opted into and then backed out off, the frame might still exist
+            portPlacementFrame = null;''',
+'''        public void StartPortPlacement()
+        {
+            // The gate click has completed. Keep its frame, but leave the gate-placement phase
+            // and remove only the temporary gate marker before deciding about a port.
+            gatePlacementActive = false;
+            ghostGateVisualEntity?.ClearEntity();
+            ghostGateVisualEntity = null;
+
+            // Ensure no previous port frame gets used. If a port was opted into and then backed out off, the frame might still exist
+            portPlacementFrame = null;''',
+"start port phase")
+
+replace_once(
+'''                        PlacementSupported = false;
+                        ShowPortPosHelp();
+                        ShowGhostPortVisualEntity(true);''',
+'''                        PlacementSupported = false;
+                        portPlacementActive = true;
+                        ShowPortPosHelp(forceShow: true);
+                        ShowGhostPortVisualEntity(true);''',
+"force port phase")
+
+replace_once(
+'''                () =>
+                {
+                    ApplyNow();
+                    return;
+                }), true, false);''',
+'''                () =>
+                {
+                    InformationManager.HideInquiry();
+                    portPlacementActive = false;
+                    ApplyNow();
+                    return;
+                }), true, false);''',
+"port no callback")
+
+replace_once(
+'''                    PlacementSupported = false;
+                    ShowGatePosHelp();
+                    ShowGhostGateVisualEntity(true);''',
+'''                    PlacementSupported = false;
+                    gatePlacementActive = true;
+                    portPlacementActive = false;
+                    ShowGatePosHelp(forceShow: true);
+                    ShowGhostGateVisualEntity(true);''',
+"force gate phase")
+
+replace_once(
+'''                    var apply = applyPending;
+                    apply.Invoke();''',
+'''                    gatePlacementActive = false;
+                    portPlacementActive = false;
+                    var apply = applyPending;
+                    apply.Invoke();''',
+"consume placement phase")
+
+replace_once(
+'''            gateSupported = false;
+            portSupported = false;
+            ghostGateVisualEntity = null;''',
+'''            gateSupported = false;
+            portSupported = false;
+            gatePlacementActive = false;
+            portPlacementActive = false;
+            ghostGateVisualEntity = null;''',
+"reset placement phases")
+
+source = source.replace(
+'''                if (ghostPortVisualEntity != null)
+                {''',
+'''                if (portPlacementActive)
+                {''',
+1)
+source = source.replace(
+'''                    var previous = ghostPortVisualEntity.GetFrame();
+
+                    portPlacementFrame = identity;''',
+'''                    portPlacementFrame = identity;''',
+1)
+source = source.replace(
+'''                if (ghostGateVisualEntity != null)
+                {''',
+'''                if (gatePlacementActive)
+                {''',
+1)
+source = source.replace(
+'''                    var previous = ghostGateVisualEntity.GetFrame();
+
+                    gatePlacementFrame = identity;''',
+'''                    gatePlacementFrame = identity;''',
+1)
+
+replace_once(
+'''                if (ghostPortVisualEntity == null)
+                {
+                    // Cannot place port, going straight to apply
+                    ClearEntities();
+                    ApplyNow();
+                }''',
+'''                if (ghostPortVisualEntity == null)
+                {
+                    // The visual marker is optional. Keep the explicit port phase active so the
+                    // mouse position is still tracked and the user can place the port safely.
+                    LogManager.EventTracer.Trace("Port marker prefab unavailable; continuing with cursor-only placement");
+                }''',
+"port marker fallback")
+
+replace_once(
+'''                if (ghostGateVisualEntity == null)
+                {
+                    // Cannot place gate, going straight to apply
+                    ClearEntities();
+                    ApplyNow();
+                }''',
+'''                if (ghostGateVisualEntity == null)
+                {
+                    // The visual marker is optional. Keep the explicit gate phase active so the
+                    // mouse position is still tracked and the user can place the gate safely.
+                    LogManager.EventTracer.Trace("Gate marker prefab unavailable; continuing with cursor-only placement");
+                }''',
+"gate marker fallback")
+
+required = [
+    "gatePlacementActive = true;",
+    "ShowGatePosHelp(forceShow: true);",
+    "ShowPortPosHelp(forceShow: true);",
+    "cursor-only placement",
+    "InformationManager.HideInquiry();\n                    portPlacementActive = false;",
+]
+for marker in required:
+    if marker not in source:
+        raise RuntimeError(f"required patched marker missing: {marker}")
+
+path.write_text(source, encoding="utf-8")


### PR DESCRIPTION
Temporary CI-only build completed successfully. Player Settlement 7.5.9.0 was compiled with a dispatcher-level post-load TickEvent readiness guard and delayed stale army-state repair, plus explicit gate/port placement phases with forced instructions, cursor-only marker fallback, and a corrected no-port callback. No MapPerfFix changes were merged.