### PR TITLE
Temporary Player Settlement 7.6.0 save-and-continue build

### DIFF
--- a/.github/workflows/temp-player-settlement-v760.yml
+++ b/.github/workflows/temp-player-settlement-v760.yml
@@ -1,0 +1,40 @@
+name: Temporary Player Settlement 7.6.0 build
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_temp_player_settlement_v760/**'
+      - '.github/workflows/temp-player-settlement-v760.yml'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download validated native-visual build inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: player-settlement-native-visuals
+          path: _downloaded_native
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: xmarre/MapPerfFix
+          run-id: 29352502369
+
+      - name: Build Player Settlement 7.6.0
+        shell: pwsh
+        run: ./_temp_player_settlement_v760/build.ps1
+
+      - name: Upload DLL and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-settlement-v760-save-continue-gate-fix
+          path: _player_settlement_v760_build/out
+          if-no-files-found: error

--- a/_temp_player_settlement_v760/SaveHandler.cs
+++ b/_temp_player_settlement_v760/SaveHandler.cs
@@ -1,0 +1,214 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+using BannerlordPlayerSettlement.Behaviours;
+
+using HarmonyLib;
+
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.SaveSystem;
+
+namespace BannerlordPlayerSettlement
+{
+    public sealed class SaveHandler
+    {
+        public enum SaveMechanism
+        {
+            Overwrite = 0,
+            Auto = 1,
+            Temporary = 2
+        }
+
+        private static readonly SaveHandler _instance = new SaveHandler();
+        public static SaveHandler Instance => _instance;
+
+        private static readonly PropertyInfo ActiveSaveSlotNameProp = AccessTools.Property(typeof(MBSaveLoad), "ActiveSaveSlotName");
+        private static readonly MethodInfo GetNextAvailableSaveNameMethod = AccessTools.Method(typeof(MBSaveLoad), "GetNextAvailableSaveName");
+
+        private bool _saveInProgress;
+        private Action<SaveMechanism, string>? _afterSave;
+        private SaveMechanism _requestedMechanism;
+        private string? _requestedSaveName;
+
+        public static void SaveLoad(SaveMechanism saveMechanism = SaveMechanism.Overwrite, Action<SaveMechanism, string>? afterSave = null)
+        {
+            Instance.SaveAndContinue(saveMechanism, afterSave);
+        }
+
+        public static void SaveOnly(bool overwrite = true)
+        {
+            Instance.Save(overwrite);
+        }
+
+        public void SaveAndContinue(SaveMechanism saveMechanism = SaveMechanism.Overwrite, Action<SaveMechanism, string>? afterSave = null)
+        {
+            if (_saveInProgress)
+            {
+                WriteTransitionLog("Save request ignored because another placement save is active");
+                return;
+            }
+
+            if (Campaign.Current?.SaveHandler == null)
+            {
+                WriteTransitionLog("Save request ignored because Campaign.SaveHandler is unavailable");
+                return;
+            }
+
+            try
+            {
+                PlayerSettlementBehaviour.Instance?.Reset();
+                WriteTransitionLog("Completed placement state cleared before save");
+            }
+            catch (Exception e)
+            {
+                WriteTransitionLog("Placement reset before save failed: " + e);
+            }
+
+            string activeName = ActiveSaveSlotNameProp.GetValue(null) as string;
+            if (string.IsNullOrWhiteSpace(activeName))
+            {
+                activeName = GetNextAvailableSaveNameMethod.Invoke(null, Array.Empty<object>()) as string;
+                if (string.IsNullOrWhiteSpace(activeName))
+                {
+                    activeName = "PlayerSettlement";
+                }
+                ActiveSaveSlotNameProp.SetValue(null, activeName);
+            }
+
+            string targetName;
+            SaveMechanism effectiveMechanism;
+            if (saveMechanism == SaveMechanism.Auto)
+            {
+                targetName = activeName + new TextObject("{=player_settlement_n_02} (auto)").ToString();
+                effectiveMechanism = SaveMechanism.Auto;
+            }
+            else
+            {
+                targetName = activeName;
+                effectiveMechanism = SaveMechanism.Overwrite;
+            }
+
+            _saveInProgress = true;
+            _afterSave = afterSave;
+            _requestedMechanism = effectiveMechanism;
+            _requestedSaveName = targetName;
+
+            CampaignEvents.OnSaveOverEvent.ClearListeners(this);
+            CampaignEvents.OnSaveOverEvent.AddNonSerializedListener(this, OnSaveCompleted);
+
+            WriteTransitionLog($"Saving placement without in-process reload: requested={saveMechanism}, effective={effectiveMechanism}, target={targetName}");
+
+            try
+            {
+                Campaign.Current.SaveHandler.SaveAs(targetName);
+            }
+            catch (Exception e)
+            {
+                WriteTransitionLog("Placement save request failed: " + e);
+                ResetPendingState();
+                throw;
+            }
+        }
+
+        public void Save(bool overwrite = true)
+        {
+            string activeName = ActiveSaveSlotNameProp.GetValue(null) as string;
+            if (string.IsNullOrWhiteSpace(activeName))
+            {
+                activeName = GetNextAvailableSaveNameMethod.Invoke(null, Array.Empty<object>()) as string;
+                if (string.IsNullOrWhiteSpace(activeName))
+                {
+                    activeName = "PlayerSettlement";
+                }
+                ActiveSaveSlotNameProp.SetValue(null, activeName);
+            }
+
+            string targetName = overwrite
+                ? activeName
+                : activeName + new TextObject("{=player_settlement_n_02} (auto)").ToString();
+            Campaign.Current.SaveHandler.SaveAs(targetName);
+        }
+
+        private void OnSaveCompleted(bool successful, string writtenName)
+        {
+            CampaignEvents.OnSaveOverEvent.ClearListeners(this);
+            WriteTransitionLog($"Placement save completed: success={successful}, written={writtenName}");
+
+            Action<SaveMechanism, string>? callback = _afterSave;
+            SaveMechanism mechanism = _requestedMechanism;
+            string requestedName = _requestedSaveName ?? writtenName;
+            ResetPendingState(clearListener: false);
+
+            if (!successful)
+            {
+                MBInformationManager.AddQuickInformation(
+                    new TextObject("{=!}Player Settlement could not save the newly created settlement."),
+                    0,
+                    Hero.MainHero?.CharacterObject);
+                return;
+            }
+
+            try
+            {
+                ActiveSaveSlotNameProp.SetValue(null, string.IsNullOrWhiteSpace(writtenName) ? requestedName : writtenName);
+            }
+            catch (Exception e)
+            {
+                WriteTransitionLog("Could not update active save slot: " + e);
+            }
+
+            try
+            {
+                callback?.Invoke(mechanism, writtenName);
+            }
+            catch (Exception e)
+            {
+                WriteTransitionLog("afterSave callback failed: " + e);
+            }
+
+            MBInformationManager.AddQuickInformation(
+                new TextObject("{=!}Settlement created and saved. Automatic in-process reload is disabled for Bannerlord 1.3.15 stability."),
+                0,
+                Hero.MainHero?.CharacterObject);
+        }
+
+        public void OnApplicationTick(float dt)
+        {
+        }
+
+        private void ResetPendingState(bool clearListener = true)
+        {
+            if (clearListener)
+            {
+                try { CampaignEvents.OnSaveOverEvent.ClearListeners(this); } catch { }
+            }
+
+            _saveInProgress = false;
+            _afterSave = null;
+            _requestedSaveName = null;
+            _requestedMechanism = SaveMechanism.Overwrite;
+        }
+
+        private static void WriteTransitionLog(string message)
+        {
+            try
+            {
+                string userDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                    "Mount and Blade II Bannerlord");
+                string directory = Path.Combine(userDir, "Configs", "BannerlordPlayerSettlement");
+                Directory.CreateDirectory(directory);
+                File.AppendAllText(
+                    Path.Combine(directory, "save_transition.log"),
+                    DateTime.UtcNow.ToString("O") + " | " + message + Environment.NewLine);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/_temp_player_settlement_v760/build.ps1
+++ b/_temp_player_settlement_v760/build.ps1
@@ -1,0 +1,92 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Join-Path $env:GITHUB_WORKSPACE '_player_settlement_v760_build'
+$src = Join-Path $root 'source'
+$out = Join-Path $root 'out'
+New-Item -ItemType Directory -Force -Path $root,$out | Out-Null
+
+$expectedCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
+$reloadCommit = 'fce517b787dbb83edb2cf2c3224b12588b8064f5'
+$v757Commit = 'e437560ef05bdd8294f794be104e7413f4d1898f'
+$v759Commit = 'a4e28c27eee7a4074d5f21f894ef0f08d97142cc'
+
+git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src
+if ($LASTEXITCODE -ne 0) { throw "git clone failed: $LASTEXITCODE" }
+git -C $src checkout $expectedCommit
+if ($LASTEXITCODE -ne 0) { throw "git checkout failed: $LASTEXITCODE" }
+
+$nativeArtifact = Join-Path $env:GITHUB_WORKSPACE '_downloaded_native'
+$nativePatch = Get-ChildItem $nativeArtifact -Recurse -Filter 'source.patch' | Select-Object -First 1
+if (-not $nativePatch) { throw '7.5.4 native-visual source.patch not found' }
+
+git -C $src apply $nativePatch.FullName
+if ($LASTEXITCODE -ne 0) { throw "native-visual patch failed: $LASTEXITCODE" }
+
+$behaviourPath = Join-Path $src 'BannerlordPlayerSettlement\Behaviours\PlayerSettlementBehaviour.cs'
+$mapPatchPath = Join-Path $src 'BannerlordPlayerSettlement\Patches\MapScreenPatch.cs'
+$saveHandlerPath = Join-Path $src 'BannerlordPlayerSettlement\SaveHandler.cs'
+$mainPath = Join-Path $src 'BannerlordPlayerSettlement\Main.cs'
+$patchDir = Join-Path $src 'BannerlordPlayerSettlement\Patches'
+$mainPatchScript = Join-Path $root 'patch_main_v756.py'
+$v759GatePatchScript = Join-Path $root 'patch_gate_workflow_v759.py'
+
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/patch_main_v756.py" -OutFile $mainPatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/LifecycleSafetyPatches.cs" -OutFile (Join-Path $patchDir 'LifecycleSafetyPatches.cs')
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v759Commit/_temp_player_settlement_v759/patch_gate_workflow_v759.py" -OutFile $v759GatePatchScript
+
+python $mainPatchScript $mainPath
+if ($LASTEXITCODE -ne 0) { throw "Main.cs lifecycle patch failed: $LASTEXITCODE" }
+
+Copy-Item (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v760\SaveHandler.cs') $saveHandlerPath -Force
+
+python $v759GatePatchScript $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.5.9 gate workflow base patch failed: $LASTEXITCODE" }
+python (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v760\patch_gate_required_v760.py') $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.0 mandatory gate patch failed: $LASTEXITCODE" }
+python (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v760\patch_map_click_v760.py') $mapPatchPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.0 map click routing patch failed: $LASTEXITCODE" }
+
+$project = Join-Path $src 'BannerlordPlayerSettlement\BannerlordPlayerSettlement.csproj'
+$projectText = Get-Content -Raw $project
+$projectText = $projectText.Replace('<Version>7.5.4</Version>', '<Version>7.6.0</Version>')
+Set-Content -Encoding UTF8 $project $projectText
+
+if (Select-String -Path $saveHandlerPath -SimpleMatch 'TryLoadSave') { throw 'Unsafe TryLoadSave call remains' }
+if (Select-String -Path $saveHandlerPath -SimpleMatch 'StartNewGame') { throw 'Unsafe StartNewGame call remains' }
+if (Select-String -Path $saveHandlerPath -SimpleMatch 'EndGame') { throw 'Unsafe EndGame call remains' }
+if (-not (Select-String -Path $saveHandlerPath -SimpleMatch 'Saving placement without in-process reload')) { throw 'Save-and-continue handler missing' }
+if (-not (Select-String -Path $behaviourPath -SimpleMatch 'Final town confirmation is impossible until a real gate position')) { throw 'Town gate requirement missing' }
+if (-not (Select-String -Path $mapPatchPath -SimpleMatch 'Placement phases own every left click')) { throw 'Map click phase routing missing' }
+if (Test-Path (Join-Path $patchDir 'GlobalCampaignTickSafetyPatch.cs')) { throw 'Obsolete global tick patch must not be present' }
+if (Test-Path (Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs')) { throw 'Obsolete army wait patch must not be present' }
+
+git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source.patch')
+Copy-Item $saveHandlerPath (Join-Path $out 'SaveHandler.cs') -Force
+Copy-Item $behaviourPath (Join-Path $out 'PlayerSettlementBehaviour.cs') -Force
+Copy-Item $mapPatchPath (Join-Path $out 'MapScreenPatch.cs') -Force
+
+& dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
+if ($LASTEXITCODE -ne 0) {
+    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 340 | ForEach-Object { Write-Host $_ }
+    throw "dotnet build failed: $LASTEXITCODE"
+}
+
+$built = Get-ChildItem (Join-Path $src 'BannerlordPlayerSettlement\bin') -Recurse -Filter 'PlayerSettlement.dll' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
+$builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
+Copy-Item $built.FullName (Join-Path $out 'PlayerSettlement.dll') -Force
+if (Test-Path $builtPdb) { Copy-Item $builtPdb (Join-Path $out 'PlayerSettlement.pdb') -Force }
+
+$version = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
+if ($version -ne '7.6.0.0') { throw "Unexpected assembly version: $version" }
+
+$dllHash = (Get-FileHash $built.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+@"
+AssemblyVersion=$version
+DLL_SHA256=$dllHash
+UpstreamCommit=$expectedCommit
+Fixes=remove unsafe in-process campaign reload; save and continue; deterministic click phase ownership; mandatory gate frame before town/castle confirmation
+"@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO.txt')
+
+Write-Host "PlayerSettlement.dll version: $version"
+Write-Host "SHA256: $dllHash"

--- a/_temp_player_settlement_v760/patch_gate_required_v760.py
+++ b/_temp_player_settlement_v760/patch_gate_required_v760.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8-sig")
+
+
+def replace_once(old: str, new: str, name: str) -> None:
+    global source
+    if old not in source:
+        raise RuntimeError(f"marker not found for {name}")
+    source = source.replace(old, new, 1)
+
+
+replace_once(
+    "if (Main.Settings == null || !Main.Settings.AllowGatePosition || !gateSupported)",
+    "if (Main.Settings == null || !gateSupported)",
+    "force gate phase for fortifications")
+
+replace_once(
+'''                        void ConfirmAndApply()
+                        {
+                            var createPlayerSettlementText = new TextObject("{=player_settlement_04}Build a Town").ToString();''',
+'''                        void ConfirmAndApply()
+                        {
+                            // Final town confirmation is impossible until a real gate position has
+                            // been recorded. This is a second line of defence if a map-click prefix
+                            // is skipped or another mod changes MapScreen click dispatch.
+                            if (gateSupported && gatePlacementFrame == null)
+                            {
+                                StartGatePlacement();
+                                return;
+                            }
+
+                            var createPlayerSettlementText = new TextObject("{=player_settlement_04}Build a Town").ToString();''',
+    "town gate requirement")
+
+replace_once(
+'''                        void ConfirmAndApply()
+                        {
+                            var createPlayerSettlementText = new TextObject("{=player_settlement_19}Build a Castle").ToString();''',
+'''                        void ConfirmAndApply()
+                        {
+                            if (gateSupported && gatePlacementFrame == null)
+                            {
+                                StartGatePlacement();
+                                return;
+                            }
+
+                            var createPlayerSettlementText = new TextObject("{=player_settlement_19}Build a Castle").ToString();''',
+    "castle gate requirement")
+
+required = [
+    "Final town confirmation is impossible until a real gate position",
+    "if (gateSupported && gatePlacementFrame == null)",
+    "if (Main.Settings == null || !gateSupported)",
+]
+for marker in required:
+    if marker not in source:
+        raise RuntimeError(f"required marker missing: {marker}")
+
+path.write_text(source, encoding="utf-8")

--- a/_temp_player_settlement_v760/patch_map_click_v760.py
+++ b/_temp_player_settlement_v760/patch_map_click_v760.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8-sig")
+
+old = '''            if (__instance.SceneLayer.Input.GetIsMouseActive() && PlayerSettlementBehaviour.Instance != null && PlayerSettlementBehaviour.Instance.IsPlacingPort && !intersectionPoint.IsOnLand && mouseOverFaceIndex.IsValid() && PlayerSettlementBehaviour.Instance.PlacementSupported)
+            {
+                PlayerSettlementBehaviour.Instance.ApplyNow();
+                return false;
+            }
+            else if (__instance.SceneLayer.Input.GetIsMouseActive() && PlayerSettlementBehaviour.Instance != null && PlayerSettlementBehaviour.Instance.IsPlacingGate && intersectionPoint.IsOnLand && PlayerSettlementBehaviour.Instance.PlacementSupported)
+            {
+                PlayerSettlementBehaviour.Instance.StartPortPlacement();
+                return false;
+            }
+            else if (__instance.SceneLayer.Input.GetIsMouseActive() && PlayerSettlementBehaviour.Instance != null && PlayerSettlementBehaviour.Instance.IsPlacingSettlement && intersectionPoint.IsOnLand && PlayerSettlementBehaviour.Instance.PlacementSupported)
+            {
+                if (PlayerSettlementBehaviour.Instance.IsDeepEdit)
+                {
+                    // TODO: Determine if raycast could select a part?
+                    return false;
+                }
+                PlayerSettlementBehaviour.Instance.StartGatePlacement();
+                return false;
+            }
+            return true;'''
+
+new = '''            PlayerSettlementBehaviour behaviour = PlayerSettlementBehaviour.Instance;
+            if (!__instance.SceneLayer.Input.GetIsMouseActive() || behaviour == null)
+            {
+                return true;
+            }
+
+            // Placement phases own every left click. Do not let the vanilla map handler select the
+            // ghost settlement or newly created town when a phase is active. OnBeforeTick already
+            // validates land/water/navigation and exposes the result through PlacementSupported.
+            if (behaviour.IsPlacingPort)
+            {
+                if (behaviour.PlacementSupported)
+                {
+                    behaviour.ApplyNow();
+                }
+                return false;
+            }
+
+            if (behaviour.IsPlacingGate)
+            {
+                if (behaviour.PlacementSupported)
+                {
+                    behaviour.StartPortPlacement();
+                }
+                return false;
+            }
+
+            if (behaviour.IsPlacingSettlement)
+            {
+                if (!behaviour.IsDeepEdit && behaviour.PlacementSupported)
+                {
+                    behaviour.StartGatePlacement();
+                }
+                return false;
+            }
+
+            return true;'''
+
+if old not in source:
+    raise RuntimeError("MapScreen placement click body marker not found")
+source = source.replace(old, new, 1)
+
+required = [
+    "Placement phases own every left click",
+    "if (behaviour.IsPlacingGate)",
+    "behaviour.StartGatePlacement();",
+    "behaviour.StartPortPlacement();",
+]
+for marker in required:
+    if marker not in source:
+        raise RuntimeError(f"required marker missing: {marker}")
+
+path.write_text(source, encoding="utf-8")


### PR DESCRIPTION
Temporary CI-only build. Removes the unsafe in-process save/load cycle entirely, saves the created settlement and continues in the current campaign, and makes placement clicks deterministic with a mandatory gate frame before town/castle confirmation. No MapPerfFix changes will be merged.