### PR TITLE
Temporary Player Settlement 7.6.1 direct gate build

### DIFF
--- a/.github/workflows/temp-player-settlement-v761.yml
+++ b/.github/workflows/temp-player-settlement-v761.yml
@@ -1,0 +1,40 @@
+name: Temporary Player Settlement 7.6.1 build
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_temp_player_settlement_v761/**'
+      - '.github/workflows/temp-player-settlement-v761.yml'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download validated native-visual build inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: player-settlement-native-visuals
+          path: _downloaded_native
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: xmarre/MapPerfFix
+          run-id: 29352502369
+
+      - name: Build Player Settlement 7.6.1
+        shell: pwsh
+        run: ./_temp_player_settlement_v761/build.ps1
+
+      - name: Upload DLL and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-settlement-v761-direct-gate-fix
+          path: _player_settlement_v761_build/out
+          if-no-files-found: error

--- a/.github/workflows/temp-player-settlement-v761.yml
+++ b/.github/workflows/temp-player-settlement-v761.yml
@@ -29,7 +29,15 @@ jobs:
 
       - name: Build Player Settlement 7.6.1
         shell: pwsh
-        run: ./_temp_player_settlement_v761/build.ps1
+        run: |
+          try {
+            ./_temp_player_settlement_v761/build.ps1
+          }
+          catch {
+            New-Item -ItemType Directory -Force -Path _player_settlement_v761_build/out | Out-Null
+            ($_ | Out-String) | Set-Content -Encoding UTF8 _player_settlement_v761_build/out/workflow_failure.txt
+            throw
+          }
 
       - name: Upload DLL and diagnostics
         if: always()

--- a/_temp_player_settlement_v761/build.ps1
+++ b/_temp_player_settlement_v761/build.ps1
@@ -1,0 +1,105 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Join-Path $env:GITHUB_WORKSPACE '_player_settlement_v761_build'
+$src = Join-Path $root 'source'
+$out = Join-Path $root 'out'
+New-Item -ItemType Directory -Force -Path $root,$out | Out-Null
+
+$expectedCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
+$reloadCommit = 'fce517b787dbb83edb2cf2c3224b12588b8064f5'
+$v757Commit = 'e437560ef05bdd8294f794be104e7413f4d1898f'
+$v759Commit = 'a4e28c27eee7a4074d5f21f894ef0f08d97142cc'
+$v760Commit = '1aaab102123f7d48fae7ae002ae3b77550e033af'
+
+git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src
+if ($LASTEXITCODE -ne 0) { throw "git clone failed: $LASTEXITCODE" }
+git -C $src checkout $expectedCommit
+if ($LASTEXITCODE -ne 0) { throw "git checkout failed: $LASTEXITCODE" }
+
+$nativeArtifact = Join-Path $env:GITHUB_WORKSPACE '_downloaded_native'
+$nativePatch = Get-ChildItem $nativeArtifact -Recurse -Filter 'source.patch' | Select-Object -First 1
+if (-not $nativePatch) { throw '7.5.4 native-visual source.patch not found' }
+
+git -C $src apply $nativePatch.FullName
+if ($LASTEXITCODE -ne 0) { throw "native-visual patch failed: $LASTEXITCODE" }
+
+$behaviourPath = Join-Path $src 'BannerlordPlayerSettlement\Behaviours\PlayerSettlementBehaviour.cs'
+$mapPatchPath = Join-Path $src 'BannerlordPlayerSettlement\Patches\MapScreenPatch.cs'
+$saveHandlerPath = Join-Path $src 'BannerlordPlayerSettlement\SaveHandler.cs'
+$mainPath = Join-Path $src 'BannerlordPlayerSettlement\Main.cs'
+$patchDir = Join-Path $src 'BannerlordPlayerSettlement\Patches'
+$mainPatchScript = Join-Path $root 'patch_main_v756.py'
+$v759GatePatchScript = Join-Path $root 'patch_gate_workflow_v759.py'
+$v760GateRequiredScript = Join-Path $root 'patch_gate_required_v760.py'
+$v760MapClickScript = Join-Path $root 'patch_map_click_v760.py'
+
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/patch_main_v756.py" -OutFile $mainPatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/LifecycleSafetyPatches.cs" -OutFile (Join-Path $patchDir 'LifecycleSafetyPatches.cs')
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v759Commit/_temp_player_settlement_v759/patch_gate_workflow_v759.py" -OutFile $v759GatePatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v760Commit/_temp_player_settlement_v760/patch_gate_required_v760.py" -OutFile $v760GateRequiredScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v760Commit/_temp_player_settlement_v760/patch_map_click_v760.py" -OutFile $v760MapClickScript
+
+python $mainPatchScript $mainPath
+if ($LASTEXITCODE -ne 0) { throw "Main.cs lifecycle patch failed: $LASTEXITCODE" }
+
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v760Commit/_temp_player_settlement_v760/SaveHandler.cs" -OutFile $saveHandlerPath
+
+python $v759GatePatchScript $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.5.9 gate workflow base patch failed: $LASTEXITCODE" }
+python $v760GateRequiredScript $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.0 mandatory gate patch failed: $LASTEXITCODE" }
+python $v760MapClickScript $mapPatchPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.0 map click base patch failed: $LASTEXITCODE" }
+python (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v761\patch_gate_commit_v761.py') $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.1 direct gate commit patch failed: $LASTEXITCODE" }
+python (Join-Path $env:GITHUB_WORKSPACE '_temp_player_settlement_v761\patch_map_click_v761.py') $mapPatchPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.1 direct map click patch failed: $LASTEXITCODE" }
+
+$project = Join-Path $src 'BannerlordPlayerSettlement\BannerlordPlayerSettlement.csproj'
+$projectText = Get-Content -Raw $project
+$projectText = $projectText.Replace('<Version>7.5.4</Version>', '<Version>7.6.1</Version>')
+Set-Content -Encoding UTF8 $project $projectText
+
+if (Select-String -Path $saveHandlerPath -SimpleMatch 'TryLoadSave') { throw 'Unsafe TryLoadSave call remains' }
+if (Select-String -Path $saveHandlerPath -SimpleMatch 'StartNewGame') { throw 'Unsafe StartNewGame call remains' }
+if (Select-String -Path $saveHandlerPath -SimpleMatch 'EndGame') { throw 'Unsafe EndGame call remains' }
+if (-not (Select-String -Path $saveHandlerPath -SimpleMatch 'Saving placement without in-process reload')) { throw 'Save-and-continue handler missing' }
+if (Select-String -Path $behaviourPath -SimpleMatch 'AllowGatePosition && gatePlacementFrame') { throw 'Persisted gate setting still discards committed frame' }
+if (Select-String -Path $behaviourPath -SimpleMatch 'FaceIslandIndex == MobileParty.MainParty.CurrentNavigationFace.FaceIslandIndex') { throw 'Brittle gate island restriction remains' }
+if (-not (Select-String -Path $behaviourPath -SimpleMatch 'CommitGatePlacement(CampaignVec2 clickPosition)')) { throw 'Direct gate commit method missing' }
+if (-not (Select-String -Path $behaviourPath -SimpleMatch 'Committed gate position directly')) { throw 'Gate commit diagnostic missing' }
+if (-not (Select-String -Path $mapPatchPath -SimpleMatch 'CommitGatePlacement(intersectionPoint)')) { throw 'Map click does not commit gate coordinates directly' }
+if (-not (Select-String -Path $mapPatchPath -SimpleMatch 'CommitSettlementPlacement(intersectionPoint)')) { throw 'Map click does not commit settlement coordinates directly' }
+if (Test-Path (Join-Path $patchDir 'GlobalCampaignTickSafetyPatch.cs')) { throw 'Obsolete global tick patch must not be present' }
+if (Test-Path (Join-Path $patchDir 'PlayerArmyWaitSafetyPatch.cs')) { throw 'Obsolete army wait patch must not be present' }
+
+git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source.patch')
+Copy-Item $saveHandlerPath (Join-Path $out 'SaveHandler.cs') -Force
+Copy-Item $behaviourPath (Join-Path $out 'PlayerSettlementBehaviour.cs') -Force
+Copy-Item $mapPatchPath (Join-Path $out 'MapScreenPatch.cs') -Force
+
+& dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
+if ($LASTEXITCODE -ne 0) {
+    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 360 | ForEach-Object { Write-Host $_ }
+    throw "dotnet build failed: $LASTEXITCODE"
+}
+
+$built = Get-ChildItem (Join-Path $src 'BannerlordPlayerSettlement\bin') -Recurse -Filter 'PlayerSettlement.dll' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
+$builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
+Copy-Item $built.FullName (Join-Path $out 'PlayerSettlement.dll') -Force
+if (Test-Path $builtPdb) { Copy-Item $builtPdb (Join-Path $out 'PlayerSettlement.pdb') -Force }
+
+$version = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
+if ($version -ne '7.6.1.0') { throw "Unexpected assembly version: $version" }
+
+$dllHash = (Get-FileHash $built.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+@"
+AssemblyVersion=$version
+DLL_SHA256=$dllHash
+UpstreamCommit=$expectedCommit
+Fixes=direct click-coordinate commits for settlement/gate/port; remove ToR-brittle FaceIslandIndex validation; always serialize mandatory gate frame; gate marker starts at settlement
+"@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO.txt')
+
+Write-Host "PlayerSettlement.dll version: $version"
+Write-Host "SHA256: $dllHash"

--- a/_temp_player_settlement_v761/build.ps1
+++ b/_temp_player_settlement_v761/build.ps1
@@ -65,7 +65,8 @@ if (Select-String -Path $saveHandlerPath -SimpleMatch 'StartNewGame') { throw 'U
 if (Select-String -Path $saveHandlerPath -SimpleMatch 'EndGame') { throw 'Unsafe EndGame call remains' }
 if (-not (Select-String -Path $saveHandlerPath -SimpleMatch 'Saving placement without in-process reload')) { throw 'Save-and-continue handler missing' }
 if (Select-String -Path $behaviourPath -SimpleMatch 'AllowGatePosition && gatePlacementFrame') { throw 'Persisted gate setting still discards committed frame' }
-if (Select-String -Path $behaviourPath -SimpleMatch 'FaceIslandIndex == MobileParty.MainParty.CurrentNavigationFace.FaceIslandIndex') { throw 'Brittle gate island restriction remains' }
+$oldGateValidation = 'bool flag = currentFace.IsValid() && isOnLand && currentFace.FaceIslandIndex == MobileParty.MainParty.CurrentNavigationFace.FaceIslandIndex;'
+if (Select-String -Path $behaviourPath -SimpleMatch $oldGateValidation) { throw 'Brittle gate island restriction remains' }
 if (-not (Select-String -Path $behaviourPath -SimpleMatch 'CommitGatePlacement(CampaignVec2 clickPosition)')) { throw 'Direct gate commit method missing' }
 if (-not (Select-String -Path $behaviourPath -SimpleMatch 'Committed gate position directly')) { throw 'Gate commit diagnostic missing' }
 if (-not (Select-String -Path $mapPatchPath -SimpleMatch 'CommitGatePlacement(intersectionPoint)')) { throw 'Map click does not commit gate coordinates directly' }

--- a/_temp_player_settlement_v761/patch_gate_commit_v761.py
+++ b/_temp_player_settlement_v761/patch_gate_commit_v761.py
@@ -23,8 +23,9 @@ source = source.replace(old_condition, "if (gateSupported && gatePlacementFrame 
 
 # The ToR map does not reliably use one FaceIslandIndex for a contiguous landmass. The old
 # comparison made the gate cursor unusable until it happened to cross a matching face.
+old_gate_validation = "bool flag = currentFace.IsValid() && isOnLand && currentFace.FaceIslandIndex == MobileParty.MainParty.CurrentNavigationFace.FaceIslandIndex; // Campaign.Current.MapSceneWrapper.AreFacesOnSameIsland(currentFace, MobileParty.MainParty.CurrentNavigationFace, ignoreDisabled: false);"
 replace_once(
-    "bool flag = currentFace.IsValid() && isOnLand && currentFace.FaceIslandIndex == MobileParty.MainParty.CurrentNavigationFace.FaceIslandIndex; // Campaign.Current.MapSceneWrapper.AreFacesOnSameIsland(currentFace, MobileParty.MainParty.CurrentNavigationFace, ignoreDisabled: false);",
+    old_gate_validation,
     "bool flag = currentFace.IsValid() && isOnLand;",
     "remove brittle gate island validation")
 
@@ -145,7 +146,7 @@ for marker in required:
 
 if old_condition in source:
     raise RuntimeError("old AllowGatePosition serialization gate remains")
-if "FaceIslandIndex == MobileParty.MainParty.CurrentNavigationFace.FaceIslandIndex" in source:
-    raise RuntimeError("old FaceIslandIndex gate validation remains")
+if old_gate_validation in source:
+    raise RuntimeError("old gate FaceIslandIndex validation remains")
 
 path.write_text(source, encoding="utf-8")

--- a/_temp_player_settlement_v761/patch_gate_commit_v761.py
+++ b/_temp_player_settlement_v761/patch_gate_commit_v761.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8-sig")
+
+
+def replace_once(old: str, new: str, name: str) -> None:
+    global source
+    if old not in source:
+        raise RuntimeError(f"marker not found for {name}")
+    source = source.replace(old, new, 1)
+
+
+# 7.6.0 forced the gate phase but the generated XML still obeyed an old persisted
+# AllowGatePosition setting. That silently discarded the selected frame and used the
+# settlement-center fallback. Once the mandatory phase ran, the committed frame must win.
+old_condition = "if (gateSupported && Main.Settings!.AllowGatePosition && gatePlacementFrame != null)"
+condition_count = source.count(old_condition)
+if condition_count != 4:
+    raise RuntimeError(f"expected 4 gate serialization conditions, found {condition_count}")
+source = source.replace(old_condition, "if (gateSupported && gatePlacementFrame != null)")
+
+# The ToR map does not reliably use one FaceIslandIndex for a contiguous landmass. The old
+# comparison made the gate cursor unusable until it happened to cross a matching face.
+replace_once(
+    "bool flag = currentFace.IsValid() && isOnLand && currentFace.FaceIslandIndex == MobileParty.MainParty.CurrentNavigationFace.FaceIslandIndex; // Campaign.Current.MapSceneWrapper.AreFacesOnSameIsland(currentFace, MobileParty.MainParty.CurrentNavigationFace, ignoreDisabled: false);",
+    "bool flag = currentFace.IsValid() && isOnLand;",
+    "remove brittle gate island validation")
+
+# Spawn the marker at the selected settlement rather than at the player party. This makes the
+# phase visually obvious even before the cursor moves.
+replace_once(
+    '''                Vec2 position2D = MobileParty.MainParty.GetPosition2D;
+
+                string prefabId = GhostGatePrefabId;''',
+    '''                Vec2 position2D = settlementPlacementFrame.HasValue
+                    ? settlementPlacementFrame.Value.origin.AsVec2
+                    : MobileParty.MainParty.GetPosition2D;
+
+                string prefabId = GhostGatePrefabId;''',
+    "gate marker initial position")
+
+# StartGatePlacement must not depend on a PlacementSupported value computed during an earlier
+# frame. The click itself is committed below and validates its own land/water state.
+replace_once(
+    '''            if (applyPending != null && mapScreen.SceneLayer.Input.GetIsMouseActive() && PlacementSupported)
+            {
+                try
+                {
+                    PlacementSupported = false;
+                    gatePlacementActive = true;''',
+    '''            if (applyPending != null && mapScreen.SceneLayer.Input.GetIsMouseActive())
+            {
+                try
+                {
+                    gatePlacementFrame = null;
+                    PlacementSupported = false;
+                    gatePlacementActive = true;''',
+    "remove stale start-gate readiness dependency")
+
+commit_methods = '''        /// <summary>
+        /// Commits the actual map click rather than trusting a placement frame calculated on a
+        /// previous camera tick. This removes timing races between cursor movement, OnBeforeTick
+        /// and MapScreen.HandleLeftMouseButtonClick.
+        /// </summary>
+        public bool CommitSettlementPlacement(CampaignVec2 clickPosition)
+        {
+            if (!IsPlacingSettlement || !clickPosition.IsOnLand)
+            {
+                return false;
+            }
+
+            MatrixFrame frame = settlementPlacementFrame ?? MatrixFrame.Identity;
+            frame.origin = clickPosition.AsVec3();
+            settlementPlacementFrame = frame;
+            SetFrame(settlementVisualEntity, ref frame);
+
+            PlacementSupported = true;
+            LogManager.EventTracer.Trace($"Committed settlement position directly: {clickPosition.X}, {clickPosition.Y}");
+            StartGatePlacement();
+            return true;
+        }
+
+        public bool CommitGatePlacement(CampaignVec2 clickPosition)
+        {
+            if (!IsPlacingGate || !clickPosition.IsOnLand)
+            {
+                return false;
+            }
+
+            MatrixFrame frame = MatrixFrame.Identity;
+            frame.origin = clickPosition.AsVec3();
+            frame.Scale(new Vec3(0.25f, 0.25f, 0.25f));
+            gatePlacementFrame = frame;
+            SetFrame(ghostGateVisualEntity, ref frame);
+
+            PlacementSupported = true;
+            LogManager.EventTracer.Trace($"Committed gate position directly: {clickPosition.X}, {clickPosition.Y}");
+            StartPortPlacement();
+            return true;
+        }
+
+        public bool CommitPortPlacement(CampaignVec2 clickPosition)
+        {
+            if (!IsPlacingPort || clickPosition.IsOnLand)
+            {
+                return false;
+            }
+
+            MatrixFrame frame = MatrixFrame.Identity;
+            frame.origin = clickPosition.AsVec3();
+            if (Game.Current.GameStateManager.ActiveState is MapState mapState && mapState.Handler is MapScreen mapScreen)
+            {
+                frame.origin.z = mapScreen.MapScene.GetWaterLevelAtPosition(frame.origin.AsVec2, true, false);
+            }
+            frame.Scale(new Vec3(0.25f, 0.25f, 0.25f));
+            portPlacementFrame = frame;
+            SetFrame(ghostPortVisualEntity, ref frame);
+
+            PlacementSupported = true;
+            LogManager.EventTracer.Trace($"Committed port position directly: {clickPosition.X}, {clickPosition.Y}");
+            ApplyNow();
+            return true;
+        }
+
+'''
+
+replace_once(
+    "        public void StartPortPlacement()\n        {",
+    commit_methods + "        public void StartPortPlacement()\n        {",
+    "insert direct placement commit methods")
+
+required = [
+    "CommitSettlementPlacement(CampaignVec2 clickPosition)",
+    "CommitGatePlacement(CampaignVec2 clickPosition)",
+    "CommitPortPlacement(CampaignVec2 clickPosition)",
+    "bool flag = currentFace.IsValid() && isOnLand;",
+    "Committed gate position directly",
+    "if (gateSupported && gatePlacementFrame != null)",
+]
+for marker in required:
+    if marker not in source:
+        raise RuntimeError(f"required patched marker missing: {marker}")
+
+if old_condition in source:
+    raise RuntimeError("old AllowGatePosition serialization gate remains")
+if "FaceIslandIndex == MobileParty.MainParty.CurrentNavigationFace.FaceIslandIndex" in source:
+    raise RuntimeError("old FaceIslandIndex gate validation remains")
+
+path.write_text(source, encoding="utf-8")

--- a/_temp_player_settlement_v761/patch_map_click_v761.py
+++ b/_temp_player_settlement_v761/patch_map_click_v761.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8-sig")
+
+old = '''            // Placement phases own every left click. Do not let the vanilla map handler select the
+            // ghost settlement or newly created town when a phase is active. OnBeforeTick already
+            // validates land/water/navigation and exposes the result through PlacementSupported.
+            if (behaviour.IsPlacingPort)
+            {
+                if (behaviour.PlacementSupported)
+                {
+                    behaviour.ApplyNow();
+                }
+                return false;
+            }
+
+            if (behaviour.IsPlacingGate)
+            {
+                if (behaviour.PlacementSupported)
+                {
+                    behaviour.StartPortPlacement();
+                }
+                return false;
+            }
+
+            if (behaviour.IsPlacingSettlement)
+            {
+                if (!behaviour.IsDeepEdit && behaviour.PlacementSupported)
+                {
+                    behaviour.StartGatePlacement();
+                }
+                return false;
+            }
+
+            return true;'''
+
+new = '''            // Placement phases own every left click. Commit the exact CampaignVec2 delivered by
+            // MapScreen instead of relying on a frame calculated during an earlier OnBeforeTick.
+            // This makes settlement -> gate -> port progression immediate and deterministic.
+            if (behaviour.IsPlacingPort)
+            {
+                behaviour.CommitPortPlacement(intersectionPoint);
+                return false;
+            }
+
+            if (behaviour.IsPlacingGate)
+            {
+                behaviour.CommitGatePlacement(intersectionPoint);
+                return false;
+            }
+
+            if (behaviour.IsPlacingSettlement)
+            {
+                if (!behaviour.IsDeepEdit)
+                {
+                    behaviour.CommitSettlementPlacement(intersectionPoint);
+                }
+                return false;
+            }
+
+            return true;'''
+
+if old not in source:
+    raise RuntimeError("7.6.0 map click body marker not found")
+source = source.replace(old, new, 1)
+
+required = [
+    "CommitSettlementPlacement(intersectionPoint)",
+    "CommitGatePlacement(intersectionPoint)",
+    "CommitPortPlacement(intersectionPoint)",
+    "immediate and deterministic",
+]
+for marker in required:
+    if marker not in source:
+        raise RuntimeError(f"required map-click marker missing: {marker}")
+
+path.write_text(source, encoding="utf-8")


### PR DESCRIPTION
Temporary CI-only build completed successfully. Player Settlement 7.6.1.0 was compiled with direct settlement/gate/port click-coordinate commits, no ToR-brittle gate FaceIslandIndex restriction, unconditional gate-frame serialization, and the 7.6.0 no-reload save-and-continue lifecycle. No MapPerfFix changes were merged.