### PR TITLE
Temporary TORCU v1.7.21 static garrison flee fix build

### DIFF
--- a/torcu-host-garrison-1721/TORCareerUniques.CompatibilityFixes.csproj
+++ b/torcu-host-garrison-1721/TORCareerUniques.CompatibilityFixes.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>TORCareerUniques.CompatibilityFixes</AssemblyName>
+    <RootNamespace>TORCareerUniques.CompatibilityFixes</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Deterministic>true</Deterministic>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="1.3.15.110062" PrivateAssets="all" />
+    <PackageReference Include="Lib.Harmony" Version="2.3.3" PrivateAssets="all" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Temporary CI-only build for TOR Career Uniques v1.7.21. Prevents roaming encounter hosts from treating static in-settlement garrisons as flee threats. Do not merge.