### PR TITLE
Temporary build: Player Settlement village raid fix

### DIFF
--- a/.github/workflows/temp-build-player-settlement-village-raid-fix.yml
+++ b/.github/workflows/temp-build-player-settlement-village-raid-fix.yml
@@ -1,0 +1,40 @@
+name: Temporary Player Settlement Village Raid Fix Build
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '_ps_village_raid_fix/**'
+      - '.github/workflows/temp-build-player-settlement-village-raid-fix.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        shell: pwsh
+        run: dotnet restore _ps_village_raid_fix/PlayerSettlementVillageRaidFix.csproj
+      - name: Build
+        shell: pwsh
+        run: dotnet build _ps_village_raid_fix/PlayerSettlementVillageRaidFix.csproj -c Release --no-restore
+      - name: Stage artifact
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifact | Out-Null
+          Copy-Item _ps_village_raid_fix/bin/Release/net472/PlayerSettlementVillageRaidFix.dll artifact/
+          Copy-Item _ps_village_raid_fix/bin/Release/net472/PlayerSettlementVillageRaidFix.pdb artifact/
+          Copy-Item _ps_village_raid_fix/PlayerSettlementVillageRaidFix.cs artifact/
+          Copy-Item _ps_village_raid_fix/PlayerSettlementVillageRaidFix.csproj artifact/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: PlayerSettlementVillageRaidFix
+          path: artifact/*
+          if-no-files-found: error

--- a/_ps_village_raid_fix/PlayerSettlementVillageRaidFix.cs
+++ b/_ps_village_raid_fix/PlayerSettlementVillageRaidFix.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace PlayerSettlementVillageRaidFix
+{
+    public sealed class SubModule : MBSubModuleBase
+    {
+        protected override void OnGameStart(Game game, IGameStarter gameStarterObject)
+        {
+            base.OnGameStart(game, gameStarterObject);
+            if (!(game.GameType is Campaign))
+                return;
+
+            CampaignEvents.OnSessionLaunchedEvent.AddNonSerializedListener(this, OnSessionLaunched);
+        }
+
+        private static void OnSessionLaunched(CampaignGameStarter starter)
+        {
+            PlayerSettlementVillageInvariantRepair.Repair();
+        }
+    }
+
+    internal static class PlayerSettlementVillageInvariantRepair
+    {
+        private const string PlayerSettlementPrefix = "player_settlement_";
+
+        private static readonly MethodInfo SettlementComponentOwnerSetter =
+            typeof(SettlementComponent)
+                .GetProperty("Owner", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                ?.GetSetMethod(true);
+
+        private static readonly MethodInfo VillageTradeBoundSetter =
+            typeof(Village)
+                .GetProperty("TradeBound", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                ?.GetSetMethod(true);
+
+        internal static void Repair()
+        {
+            Campaign campaign = Campaign.Current;
+            if (campaign == null)
+                return;
+
+            int checkedVillages = 0;
+            int repairedReferences = 0;
+            int unresolvedVillages = 0;
+
+            foreach (Settlement settlement in Settlement.All)
+            {
+                if (!IsPlayerSettlementVillage(settlement))
+                    continue;
+
+                checkedVillages++;
+                try
+                {
+                    Village village = settlement.Village;
+                    bool unresolved = false;
+
+                    if (village.Owner == null)
+                    {
+                        if (settlement.Party != null && SettlementComponentOwnerSetter != null)
+                        {
+                            SettlementComponentOwnerSetter.Invoke(village, new object[] { settlement.Party });
+                            repairedReferences++;
+                        }
+                        else
+                        {
+                            unresolved = true;
+                        }
+                    }
+
+                    Settlement bound = village.Bound;
+                    if (bound == null)
+                    {
+                        unresolved = true;
+                    }
+                    else
+                    {
+                        if (bound.IsFortification && bound.OwnerClan == null &&
+                            IsPlayerSettlement(bound) && bound.Town != null && Clan.PlayerClan != null)
+                        {
+                            bound.Town.OwnerClan = Clan.PlayerClan;
+                            repairedReferences++;
+                        }
+
+                        if (bound.OwnerClan == null || bound.MapFaction == null)
+                            unresolved = true;
+
+                        if (bound.IsCastle && village.TradeBound == null)
+                        {
+                            Settlement tradeBound = campaign.Models.VillageTradeModel
+                                .GetTradeBoundToAssignForVillage(village);
+
+                            if (tradeBound != null && tradeBound.IsTown && VillageTradeBoundSetter != null)
+                            {
+                                VillageTradeBoundSetter.Invoke(village, new object[] { tradeBound });
+                                repairedReferences++;
+                            }
+                            else
+                            {
+                                unresolved = true;
+                            }
+                        }
+                    }
+
+                    if (village.Owner == null || village.Settlement == null)
+                        unresolved = true;
+
+                    if (unresolved)
+                        unresolvedVillages++;
+                }
+                catch (Exception ex)
+                {
+                    unresolvedVillages++;
+                    Debug.Print("[PlayerSettlementVillageRaidFix] Failed to repair " +
+                                settlement.StringId + ": " + ex);
+                }
+            }
+
+            Debug.Print("[PlayerSettlementVillageRaidFix] Checked " + checkedVillages +
+                        " player village(s); restored " + repairedReferences +
+                        " missing native reference(s); unresolved " + unresolvedVillages + ".");
+        }
+
+        private static bool IsPlayerSettlementVillage(Settlement settlement)
+        {
+            return settlement != null && settlement.IsVillage && settlement.Village != null &&
+                   IsPlayerSettlement(settlement);
+        }
+
+        private static bool IsPlayerSettlement(Settlement settlement)
+        {
+            return settlement != null && !String.IsNullOrEmpty(settlement.StringId) &&
+                   settlement.StringId.StartsWith(PlayerSettlementPrefix, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/_ps_village_raid_fix/PlayerSettlementVillageRaidFix.csproj
+++ b/_ps_village_raid_fix/PlayerSettlementVillageRaidFix.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <AssemblyName>PlayerSettlementVillageRaidFix</AssemblyName>
+    <RootNamespace>PlayerSettlementVillageRaidFix</RootNamespace>
+    <Version>7.6.7</Version>
+    <Platforms>x64</Platforms>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="1.3.15.110062" PrivateAssets="all" />
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.Native" Version="1.3.15.110062" PrivateAssets="all" />
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.SandBox" Version="1.3.15.110062" PrivateAssets="all" />
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.StoryMode" Version="1.3.15.110062" PrivateAssets="all" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Temporary isolated build branch for the Bannerlord 1.3.15 Player Settlements village-raid invariant repair. Build artifact retrieved and validated. Closed without merge.