### PR TITLE
Temporary build: Player Settlement culture helper loader

### DIFF
--- a/.github/workflows/temp-build-player-settlement-culture-loader-7681.yml
+++ b/.github/workflows/temp-build-player-settlement-culture-loader-7681.yml
@@ -1,0 +1,40 @@
+name: Temporary Player Settlement Culture Loader 7.6.8.1 Build
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_ps_culture_loader_7681/**'
+      - '.github/workflows/temp-build-player-settlement-culture-loader-7681.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        shell: pwsh
+        run: dotnet restore _ps_culture_loader_7681/PlayerSettlementCultureVisuals.csproj
+      - name: Build
+        shell: pwsh
+        run: dotnet build _ps_culture_loader_7681/PlayerSettlementCultureVisuals.csproj -c Release --no-restore
+      - name: Stage artifact
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifact | Out-Null
+          Copy-Item _ps_culture_loader_7681/bin/Release/net472/PlayerSettlementCultureVisuals.dll artifact/
+          Copy-Item _ps_culture_loader_7681/bin/Release/net472/PlayerSettlementCultureVisuals.pdb artifact/
+          Copy-Item _ps_culture_loader_7681/CultureVisualHelper.cs artifact/
+          Copy-Item _ps_culture_loader_7681/PlayerSettlementCultureVisuals.csproj artifact/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: PlayerSettlementCultureVisuals-7.6.8.1
+          path: artifact/*
+          if-no-files-found: error
+          retention-days: 1

--- a/_ps_culture_loader_7681/CultureVisualHelper.cs
+++ b/_ps_culture_loader_7681/CultureVisualHelper.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("7.6.8.1")]
+
+namespace PlayerSettlementCultureVisuals
+{
+    public sealed class SubModule : MBSubModuleBase
+    {
+    }
+}
+
+namespace BannerlordPlayerSettlement.Patches
+{
+    public static class CultureVisualHelper
+    {
+        private const string TorTemplateMarker = "_ToR";
+        private const string PlayerSettlementPrefix = "player_settlement_";
+
+        public static GameEntity TryCopyExistingSettlementVisual(
+            Scene scene,
+            string cultureId,
+            int settlementType,
+            string templateId,
+            string entityId,
+            Vec2 position)
+        {
+            if (scene == null ||
+                string.IsNullOrEmpty(cultureId) ||
+                !IsTorIdentifier(templateId))
+            {
+                return null;
+            }
+
+            return CopyMatchingVisual(
+                scene,
+                cultureId,
+                settlementType,
+                templateId,
+                entityId,
+                position);
+        }
+
+        public static GameEntity TryCopyCreatedSettlementVisual(
+            Scene scene,
+            string settlementId,
+            Vec2 position)
+        {
+            if (scene == null || !IsTorIdentifier(settlementId))
+                return null;
+
+            Settlement target = Settlement.Find(settlementId);
+            if (target == null || target.Culture == null)
+                return null;
+
+            int settlementType = target.IsTown ? 1 : target.IsVillage ? 2 : target.IsCastle ? 3 : 0;
+            if (settlementType == 0)
+                return null;
+
+            return CopyMatchingVisual(
+                scene,
+                target.Culture.StringId,
+                settlementType,
+                settlementId,
+                settlementId,
+                position);
+        }
+
+        private static GameEntity CopyMatchingVisual(
+            Scene scene,
+            string cultureId,
+            int settlementType,
+            string variantKey,
+            string entityId,
+            Vec2 position)
+        {
+            var candidates = new List<Settlement>();
+            foreach (Settlement settlement in Settlement.All)
+            {
+                if (!IsMatchingSource(settlement, cultureId, settlementType))
+                    continue;
+
+                GameEntity source = scene.GetCampaignEntityWithName(settlement.StringId);
+                if (source != null)
+                    candidates.Add(settlement);
+            }
+
+            if (candidates.Count == 0 && (settlementType == 1 || settlementType == 3))
+            {
+                foreach (Settlement settlement in Settlement.All)
+                {
+                    if (!IsSameCultureSource(settlement, cultureId) ||
+                        (!settlement.IsTown && !settlement.IsCastle))
+                    {
+                        continue;
+                    }
+
+                    GameEntity source = scene.GetCampaignEntityWithName(settlement.StringId);
+                    if (source != null)
+                        candidates.Add(settlement);
+                }
+            }
+
+            if (candidates.Count == 0)
+                return null;
+
+            int startIndex = GetVariantIndex(variantKey, candidates.Count);
+            for (int offset = 0; offset < candidates.Count; offset++)
+            {
+                Settlement settlement = candidates[(startIndex + offset) % candidates.Count];
+                GameEntity source = scene.GetCampaignEntityWithName(settlement.StringId);
+                if (source == null)
+                    continue;
+
+                GameEntity copy = GameEntity.CopyFromPrefab(source);
+                if (copy == null)
+                    continue;
+
+                copy.Name = entityId;
+                Vec3 position3D = new Vec3(position.x, position.y, 0f, -1f);
+                position3D.z = scene.GetGroundHeightAtPosition(
+                    position.ToVec3(0f),
+                    (BodyFlags)544321929);
+                copy.SetLocalPosition(position3D);
+                return copy;
+            }
+
+            return null;
+        }
+
+        private static bool IsMatchingSource(
+            Settlement settlement,
+            string cultureId,
+            int settlementType)
+        {
+            if (!IsSameCultureSource(settlement, cultureId))
+                return false;
+
+            if (settlementType == 1)
+                return settlement.IsTown;
+            if (settlementType == 2)
+                return settlement.IsVillage;
+            if (settlementType == 3)
+                return settlement.IsCastle;
+
+            return false;
+        }
+
+        private static bool IsSameCultureSource(Settlement settlement, string cultureId)
+        {
+            if (settlement == null || settlement.Culture == null || !settlement.IsVisible)
+                return false;
+
+            if (!string.Equals(
+                    settlement.Culture.StringId,
+                    cultureId,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return string.IsNullOrEmpty(settlement.StringId) ||
+                   !settlement.StringId.StartsWith(
+                       PlayerSettlementPrefix,
+                       StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsTorIdentifier(string value)
+        {
+            return !string.IsNullOrEmpty(value) &&
+                   value.IndexOf(TorTemplateMarker, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static int GetVariantIndex(string value, int candidateCount)
+        {
+            if (candidateCount <= 1 || string.IsNullOrEmpty(value))
+                return 0;
+
+            const string marker = "_variant_";
+            int markerIndex = value.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (markerIndex < 0)
+                return 0;
+
+            int start = markerIndex + marker.Length;
+            int end = start;
+            while (end < value.Length && char.IsDigit(value[end]))
+                end++;
+
+            int variant;
+            if (end <= start || !int.TryParse(value.Substring(start, end - start), out variant))
+                return 0;
+
+            return Math.Max(0, variant - 1) % candidateCount;
+        }
+    }
+}

--- a/_ps_culture_loader_7681/PlayerSettlementCultureVisuals.csproj
+++ b/_ps_culture_loader_7681/PlayerSettlementCultureVisuals.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>PlayerSettlementCultureVisuals</AssemblyName>
+    <RootNamespace>BannerlordPlayerSettlement.Patches</RootNamespace>
+    <Version>1.0.0</Version>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Platforms>x64</Platforms>
+    <Deterministic>true</Deterministic>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="1.3.15.110062" PrivateAssets="all" />
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.Native" Version="1.3.15.110062" PrivateAssets="all" />
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.SandBox" Version="1.3.15.110062" PrivateAssets="all" />
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.StoryMode" Version="1.3.15.110062" PrivateAssets="all" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Temporary CI-only build for Player Settlements 7.6.8.1. Rebuilt PlayerSettlementCultureVisuals as an explicit MBSubModuleBase entry, retrieved the successful build artifact, integrated it into the release package, and completed archive validation. Closed without merge.