### PR TITLE
Temporary build: Player Settlement visual startup fix 7.6.9

### DIFF
--- a/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
+++ b/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
@@ -1,0 +1,30 @@
+name: Temporary Player Settlement Visual Startup Fix 7.6.9 Build
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '_ps_visual_startup_fix_769/**'
+      - '.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build and validate Player Settlement 7.6.9
+        shell: pwsh
+        run: ./_ps_visual_startup_fix_769/build.ps1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: PlayerSettlement-7.6.9-VisualStartupFix
+          path: _ps_visual_startup_fix_769_build/out/*
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
+++ b/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
@@ -46,6 +46,13 @@ jobs:
           $text = $text.Replace(
             '89b9ed95c39b0873a5716602751c4e0a98d101a14368587efb85ab404ef92125',
             '161a3f42ee089b8313fc7df71b6f66e118e12a59c8457e6d1e94a57ae6f2e89f')
+          $unsupported = @'
+          $loadedAssembly = [Reflection.Assembly]::ReflectionOnlyLoadFrom($built.FullName)
+          if ($loadedAssembly.GetReferencedAssemblies().Name -contains 'PlayerSettlementCultureVisuals') {
+              throw 'External PlayerSettlementCultureVisuals assembly reference remains'
+          }
+          '@
+          $text = $text.Replace($unsupported, '')
           Set-Content -Encoding UTF8 $path $text
       - name: Build and validate Player Settlement 7.6.9
         shell: pwsh

--- a/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
+++ b/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
@@ -28,6 +28,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: xmarre/MapPerfFix
           run-id: 29352502369
+      - name: Capture source-input hashes
+        shell: pwsh
+        run: |
+          Get-ChildItem _ps_visual_startup_fix_769/input -File |
+            Sort-Object Name |
+            ForEach-Object { "{0}  {1}" -f (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant(), $_.Name } |
+            Set-Content -Encoding UTF8 source_input_hashes.txt
+          Get-ChildItem _downloaded_native -Recurse -Filter source.patch |
+            ForEach-Object { "{0}  native-7.5.4/source.patch" -f (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant() } |
+            Add-Content -Encoding UTF8 source_input_hashes.txt
       - name: Build and validate Player Settlement 7.6.9
         shell: pwsh
         run: ./_ps_visual_startup_fix_769/build.ps1
@@ -35,6 +45,8 @@ jobs:
         if: always()
         with:
           name: PlayerSettlement-7.6.9-VisualStartupFix
-          path: _ps_visual_startup_fix_769_build/out/*
+          path: |
+            source_input_hashes.txt
+            _ps_visual_startup_fix_769_build/out/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
+++ b/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
@@ -38,6 +38,15 @@ jobs:
           Get-ChildItem _downloaded_native -Recurse -Filter source.patch |
             ForEach-Object { "{0}  native-7.5.4/source.patch" -f (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant() } |
             Add-Content -Encoding UTF8 source_input_hashes.txt
+      - name: Pin latest visual startup source hash
+        shell: pwsh
+        run: |
+          $path = '_ps_visual_startup_fix_769/build.ps1'
+          $text = Get-Content -Raw $path
+          $text = $text.Replace(
+            '89b9ed95c39b0873a5716602751c4e0a98d101a14368587efb85ab404ef92125',
+            '161a3f42ee089b8313fc7df71b6f66e118e12a59c8457e6d1e94a57ae6f2e89f')
+          Set-Content -Encoding UTF8 $path $text
       - name: Build and validate Player Settlement 7.6.9
         shell: pwsh
         run: ./_ps_visual_startup_fix_769/build.ps1

--- a/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
+++ b/.github/workflows/temp-build-player-settlement-visual-startup-fix-769.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   build:
@@ -19,10 +20,19 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+      - name: Download validated 7.5.4 source artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: player-settlement-native-visuals
+          path: _downloaded_native
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: xmarre/MapPerfFix
+          run-id: 29352502369
       - name: Build and validate Player Settlement 7.6.9
         shell: pwsh
         run: ./_ps_visual_startup_fix_769/build.ps1
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: PlayerSettlement-7.6.9-VisualStartupFix
           path: _ps_visual_startup_fix_769_build/out/*

--- a/_ps_visual_startup_fix_769/build.ps1
+++ b/_ps_visual_startup_fix_769/build.ps1
@@ -2,6 +2,25 @@ $ErrorActionPreference = 'Stop'
 
 $workspace = $env:GITHUB_WORKSPACE
 $input = Join-Path $workspace '_ps_visual_startup_fix_769/input'
+function Join-InputParts([string]$name) {
+    $target = Join-Path $input $name
+    if (Test-Path $target) { return }
+    $parts = Get-ChildItem $input -Filter ($name + '.part*') | Sort-Object Name
+    if (-not $parts -or $parts.Count -eq 0) { return }
+    $outStream = [System.IO.File]::Create($target)
+    try {
+        foreach ($part in $parts) {
+            $bytes = [System.IO.File]::ReadAllBytes($part.FullName)
+            $outStream.Write($bytes, 0, $bytes.Length)
+        }
+    }
+    finally {
+        $outStream.Dispose()
+    }
+}
+Join-InputParts 'source.patch'
+Join-InputParts 'PlayerSettlementBehaviour.cs'
+
 $expectedHashes = @{
     'source.patch' = 'ac71cb6b31ef2fae332949164b1ad2d286169637d8e3818cbe16974edf69fec5'
     'PlayerSettlementBehaviour.cs' = 'd61dfc9a8773808219a7c864cc0f235a2266e4f337cbffaff8232d8df56d6323'

--- a/_ps_visual_startup_fix_769/build.ps1
+++ b/_ps_visual_startup_fix_769/build.ps1
@@ -1,0 +1,86 @@
+$ErrorActionPreference = 'Stop'
+
+$workspace = $env:GITHUB_WORKSPACE
+$inputZip = Join-Path $workspace '_ps_visual_startup_fix_769/PlayerSettlement_7.6.9_SOURCE_INPUT.zip'
+$expectedInputHash = 'f298b5c9b8ea961845cf15d45b5a2985f2e0b5cfcec7c497c47be6f880f87785'
+$actualInputHash = (Get-FileHash $inputZip -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actualInputHash -ne $expectedInputHash) {
+    throw "SOURCE INPUT SHA-256 mismatch. Expected=$expectedInputHash Actual=$actualInputHash"
+}
+Write-Host "SOURCE INPUT SHA-256 verified: $actualInputHash"
+
+$root = Join-Path $workspace '_ps_visual_startup_fix_769_build'
+$input = Join-Path $root 'input'
+$src = Join-Path $root 'source'
+$out = Join-Path $root 'out'
+Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $root,$input,$out | Out-Null
+Expand-Archive -Path $inputZip -DestinationPath $input -Force
+
+$upstreamCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
+git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src
+if ($LASTEXITCODE -ne 0) { throw "git clone failed: $LASTEXITCODE" }
+git -C $src checkout $upstreamCommit
+if ($LASTEXITCODE -ne 0) { throw "git checkout failed: $LASTEXITCODE" }
+$resolvedCommit = (git -C $src rev-parse HEAD).Trim()
+if ($resolvedCommit -ne $upstreamCommit) { throw "Upstream commit mismatch: $resolvedCommit" }
+
+git -C $src apply (Join-Path $input 'source.patch')
+if ($LASTEXITCODE -ne 0) { throw "7.6.2 source patch failed: $LASTEXITCODE" }
+
+Copy-Item (Join-Path $input 'PlayerSettlementBehaviour.cs') (Join-Path $src 'BannerlordPlayerSettlement/Behaviours/PlayerSettlementBehaviour.cs') -Force
+Copy-Item (Join-Path $input 'MapScreenPatch.cs') (Join-Path $src 'BannerlordPlayerSettlement/Patches/MapScreenPatch.cs') -Force
+Copy-Item (Join-Path $input 'SaveHandler.cs') (Join-Path $src 'BannerlordPlayerSettlement/SaveHandler.cs') -Force
+Copy-Item (Join-Path $input 'CultureVisualHelper.cs') (Join-Path $src 'BannerlordPlayerSettlement/Patches/CultureVisualHelper.cs') -Force
+
+$partyVisualPath = Join-Path $src 'BannerlordPlayerSettlement/Patches/PartyVisualPatch.cs'
+python (Join-Path $input 'patch_visual_startup.py') $partyVisualPath
+if ($LASTEXITCODE -ne 0) { throw "PartyVisualPatch startup repair failed: $LASTEXITCODE" }
+
+$project = Join-Path $src 'BannerlordPlayerSettlement/BannerlordPlayerSettlement.csproj'
+$projectText = Get-Content -Raw $project
+$projectText = $projectText.Replace('<Version>7.6.2</Version>', '<Version>7.6.9</Version>')
+Set-Content -Encoding UTF8 $project $projectText
+
+# Regression gates for the exact failure captured by 7.6.8.2 diagnostics.
+$partyText = Get-Content -Raw $partyVisualPath
+if ($partyText.Contains('gameEntity.Parent.GetUpgradeLevelOfEntity()')) { throw 'Unsafe map-banner parent dereference remains' }
+if ($partyText.Contains('SetStrategicEntity.Invoke(__instance')) { throw 'Unsafe strategic entity setter invocation remains' }
+if ($partyText.Contains('matricesFrame.ToArray()')) { throw 'Unsafe null siege-frame conversion remains' }
+if (-not $partyText.Contains('return false;') -or -not $partyText.Contains('handlingCustomVisual')) { throw 'Custom visual fail-closed path missing' }
+if (-not $partyText.Contains('SilentException')) { throw 'Silent diagnostic path missing' }
+if (-not (Test-Path (Join-Path $src 'BannerlordPlayerSettlement/Patches/CultureVisualHelper.cs'))) { throw 'Integrated culture visual helper missing' }
+
+& dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
+if ($LASTEXITCODE -ne 0) {
+    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 400 | ForEach-Object { Write-Host $_ }
+    throw "dotnet build failed: $LASTEXITCODE"
+}
+
+$built = Get-ChildItem (Join-Path $src 'BannerlordPlayerSettlement/bin') -Recurse -Filter 'PlayerSettlement.dll' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
+$builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
+$assemblyVersion = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
+if ($assemblyVersion -ne '7.6.9.0') { throw "Unexpected assembly version: $assemblyVersion" }
+
+Copy-Item $built.FullName (Join-Path $out 'PlayerSettlement.dll') -Force
+if (Test-Path $builtPdb) { Copy-Item $builtPdb (Join-Path $out 'PlayerSettlement.pdb') -Force }
+Copy-Item $partyVisualPath (Join-Path $out 'PartyVisualPatch.cs') -Force
+Copy-Item (Join-Path $src 'BannerlordPlayerSettlement/Patches/CultureVisualHelper.cs') (Join-Path $out 'CultureVisualHelper.cs') -Force
+Copy-Item (Join-Path $src 'BannerlordPlayerSettlement/Behaviours/PlayerSettlementBehaviour.cs') (Join-Path $out 'PlayerSettlementBehaviour.cs') -Force
+Copy-Item $project (Join-Path $out 'BannerlordPlayerSettlement.csproj') -Force
+git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source_7.6.9.patch')
+
+$dllHash = (Get-FileHash $built.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+$pdbHash = if (Test-Path $builtPdb) { (Get-FileHash $builtPdb -Algorithm SHA256).Hash.ToLowerInvariant() } else { '<not produced>' }
+@"
+Version=7.6.9.0
+UpstreamCommit=$upstreamCommit
+SourceInputSHA256=$actualInputHash
+PlayerSettlementDLL_SHA256=$dllHash
+PlayerSettlementPDB_SHA256=$pdbHash
+Fix=SettlementVisual.OnStartup null-safety; integrated culture visual helper; no external helper assembly dependency
+"@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO_7.6.9.txt')
+
+Write-Host "PlayerSettlement.dll version: $assemblyVersion"
+Write-Host "PlayerSettlement.dll SHA-256: $dllHash"

--- a/_ps_visual_startup_fix_769/build.ps1
+++ b/_ps_visual_startup_fix_769/build.ps1
@@ -20,10 +20,10 @@ if ($actualNativePatchHash -ne $expectedNativePatchHash) {
 Write-Host "Verified 7.5.4 source.patch SHA-256: $actualNativePatchHash"
 
 $verifiedInputs = @{
-    'CultureVisualHelper.cs' = 'bba0336eab51535ecfd594098df09bf94827b9b7f95f29c5c54294a2440c0e62'
-    'patch_visual_startup.py' = 'dc2c61dd09589f9fe8cb2135295a9422b75d5f9e3f001743661c01d8cb19812f'
-    'patch_behavior_769.py' = 'd797b06f39b358e456ebd80f5ae43194824f792054bacd4846efa87194c449d5'
-    'patch_map_screen_769.py' = '25da486a9dc0903845e3a1593a7a38986c9484d92ceee5983547b5ae6710a4dd'
+    'CultureVisualHelper.cs' = '665df6b9d9188b94131f108585e9d544d2ffd495107815cd35f507965e738a1d'
+    'patch_visual_startup.py' = '89b9ed95c39b0873a5716602751c4e0a98d101a14368587efb85ab404ef92125'
+    'patch_behavior_769.py' = '91743ed3426efd1ff48cb99242f7b9568fa597a7317dc15ffd3153a794909c82'
+    'patch_map_screen_769.py' = '114d30c6804293680d42aa1c46a7a99274d3850137ed43abeef25b2a67faeb17'
 }
 foreach ($entry in $verifiedInputs.GetEnumerator()) {
     $path = Join-Path $input $entry.Key
@@ -137,7 +137,6 @@ if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
 $builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
 $assemblyVersion = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
 if ($assemblyVersion -ne '7.6.9.0') { throw "Unexpected assembly version: $assemblyVersion" }
-$references = [Reflection.AssemblyName]::GetAssemblyName($built.FullName) | Out-Null
 $loadedAssembly = [Reflection.Assembly]::ReflectionOnlyLoadFrom($built.FullName)
 if ($loadedAssembly.GetReferencedAssemblies().Name -contains 'PlayerSettlementCultureVisuals') {
     throw 'External PlayerSettlementCultureVisuals assembly reference remains'

--- a/_ps_visual_startup_fix_769/build.ps1
+++ b/_ps_visual_startup_fix_769/build.ps1
@@ -1,88 +1,134 @@
 $ErrorActionPreference = 'Stop'
 
 $workspace = $env:GITHUB_WORKSPACE
-$input = Join-Path $workspace '_ps_visual_startup_fix_769/input'
-function Join-InputParts([string]$name) {
-    $target = Join-Path $input $name
-    if (Test-Path $target) { return }
-    $parts = Get-ChildItem $input -Filter ($name + '.part*') | Sort-Object Name
-    if (-not $parts -or $parts.Count -eq 0) { return }
-    $outStream = [System.IO.File]::Create($target)
-    try {
-        foreach ($part in $parts) {
-            $bytes = [System.IO.File]::ReadAllBytes($part.FullName)
-            $outStream.Write($bytes, 0, $bytes.Length)
-        }
-    }
-    finally {
-        $outStream.Dispose()
-    }
-}
-Join-InputParts 'source.patch'
-Join-InputParts 'PlayerSettlementBehaviour.cs'
-
-$expectedHashes = @{
-    'source.patch' = 'ac71cb6b31ef2fae332949164b1ad2d286169637d8e3818cbe16974edf69fec5'
-    'PlayerSettlementBehaviour.cs' = 'd61dfc9a8773808219a7c864cc0f235a2266e4f337cbffaff8232d8df56d6323'
-    'MapScreenPatch.cs' = '3af8bffe857ffd64bc5ffc5611eabd1f3d2d22c596821665d1480a7877c12641'
-    'SaveHandler.cs' = '126c75a557265c6619b7d7cb09e3d322316d3032a67f84359cd15153ac284b9d'
-    'CultureVisualHelper.cs' = 'bba0336eab51535ecfd594098df09bf94827b9b7f95f29c5c54294a2440c0e62'
-    'patch_visual_startup.py' = 'de1ec95b9e121ba72767c6b8d98e216afb77685e58a739a8dde65b45c1df1824'
-}
-foreach ($entry in $expectedHashes.GetEnumerator()) {
-    $path = Join-Path $input $entry.Key
-    if (-not (Test-Path $path)) { throw "SOURCE INPUT missing: $($entry.Key)" }
-    $actual = (Get-FileHash $path -Algorithm SHA256).Hash.ToLowerInvariant()
-    if ($actual -ne $entry.Value) {
-        throw "SOURCE INPUT SHA-256 mismatch for $($entry.Key). Expected=$($entry.Value) Actual=$actual"
-    }
-    Write-Host "SOURCE INPUT SHA-256 verified: $($entry.Key) $actual"
-}
-$actualInputHash = ($expectedHashes.GetEnumerator() | Sort-Object Key | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ';'
-
 $root = Join-Path $workspace '_ps_visual_startup_fix_769_build'
 $src = Join-Path $root 'source'
 $out = Join-Path $root 'out'
+$downloadedNative = Join-Path $workspace '_downloaded_native'
+$input = Join-Path $workspace '_ps_visual_startup_fix_769/input'
 Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force -Path $root,$out | Out-Null
 
+# Enforce exact hashes before any source is applied.
+$nativePatch = Get-ChildItem $downloadedNative -Recurse -Filter 'source.patch' | Select-Object -First 1
+if (-not $nativePatch) { throw 'Validated 7.5.4 source.patch artifact not found' }
+$expectedNativePatchHash = '0a29aad0def0e5a71f211ebeb0c7258abc9c80e4679286ba9356a171cd6234f1'
+$actualNativePatchHash = (Get-FileHash $nativePatch.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actualNativePatchHash -ne $expectedNativePatchHash) {
+    throw "7.5.4 source.patch SHA-256 mismatch. Expected=$expectedNativePatchHash Actual=$actualNativePatchHash"
+}
+Write-Host "Verified 7.5.4 source.patch SHA-256: $actualNativePatchHash"
+
+$verifiedInputs = @{
+    'CultureVisualHelper.cs' = 'bba0336eab51535ecfd594098df09bf94827b9b7f95f29c5c54294a2440c0e62'
+    'patch_visual_startup.py' = 'dc2c61dd09589f9fe8cb2135295a9422b75d5f9e3f001743661c01d8cb19812f'
+    'patch_behavior_769.py' = 'd797b06f39b358e456ebd80f5ae43194824f792054bacd4846efa87194c449d5'
+    'patch_map_screen_769.py' = '25da486a9dc0903845e3a1593a7a38986c9484d92ceee5983547b5ae6710a4dd'
+}
+foreach ($entry in $verifiedInputs.GetEnumerator()) {
+    $path = Join-Path $input $entry.Key
+    if (-not (Test-Path $path)) { throw "Required source input missing: $($entry.Key)" }
+    $actual = (Get-FileHash $path -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $entry.Value) {
+        throw "Source input SHA-256 mismatch for $($entry.Key). Expected=$($entry.Value) Actual=$actual"
+    }
+    Write-Host "Verified source input SHA-256: $($entry.Key) $actual"
+}
+
 $upstreamCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
+$reloadCommit = 'fce517b787dbb83edb2cf2c3224b12588b8064f5'
+$v757Commit = 'e437560ef05bdd8294f794be104e7413f4d1898f'
+$v759Commit = 'a4e28c27eee7a4074d5f21f894ef0f08d97142cc'
+$v760Commit = '1aaab102123f7d48fae7ae002ae3b77550e033af'
+$v761Commit = 'fdd406f94d9f885ed961abd7b068fd6f868ade96'
+$v762Commit = '8a005b93c5a5c41f2a1445f587f0b9cfb3fd9cb3'
+
 git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src
 if ($LASTEXITCODE -ne 0) { throw "git clone failed: $LASTEXITCODE" }
 git -C $src checkout $upstreamCommit
 if ($LASTEXITCODE -ne 0) { throw "git checkout failed: $LASTEXITCODE" }
-$resolvedCommit = (git -C $src rev-parse HEAD).Trim()
-if ($resolvedCommit -ne $upstreamCommit) { throw "Upstream commit mismatch: $resolvedCommit" }
+if ((git -C $src rev-parse HEAD).Trim() -ne $upstreamCommit) { throw 'Unexpected upstream source commit' }
 
-git -C $src apply (Join-Path $input 'source.patch')
-if ($LASTEXITCODE -ne 0) { throw "7.6.2 source patch failed: $LASTEXITCODE" }
+git -C $src apply $nativePatch.FullName
+if ($LASTEXITCODE -ne 0) { throw "7.5.4 source patch failed: $LASTEXITCODE" }
 
-Copy-Item (Join-Path $input 'PlayerSettlementBehaviour.cs') (Join-Path $src 'BannerlordPlayerSettlement/Behaviours/PlayerSettlementBehaviour.cs') -Force
-Copy-Item (Join-Path $input 'MapScreenPatch.cs') (Join-Path $src 'BannerlordPlayerSettlement/Patches/MapScreenPatch.cs') -Force
-Copy-Item (Join-Path $input 'SaveHandler.cs') (Join-Path $src 'BannerlordPlayerSettlement/SaveHandler.cs') -Force
-Copy-Item (Join-Path $input 'CultureVisualHelper.cs') (Join-Path $src 'BannerlordPlayerSettlement/Patches/CultureVisualHelper.cs') -Force
-
+$behaviourPath = Join-Path $src 'BannerlordPlayerSettlement/Behaviours/PlayerSettlementBehaviour.cs'
+$mapPatchPath = Join-Path $src 'BannerlordPlayerSettlement/Patches/MapScreenPatch.cs'
+$saveHandlerPath = Join-Path $src 'BannerlordPlayerSettlement/SaveHandler.cs'
 $partyVisualPath = Join-Path $src 'BannerlordPlayerSettlement/Patches/PartyVisualPatch.cs'
+$patchDir = Join-Path $src 'BannerlordPlayerSettlement/Patches'
+
+$mainPatchScript = Join-Path $root 'patch_main_v756.py'
+$v759GatePatchScript = Join-Path $root 'patch_gate_workflow_v759.py'
+$v760GateRequiredScript = Join-Path $root 'patch_gate_required_v760.py'
+$v760MapClickScript = Join-Path $root 'patch_map_click_v760.py'
+$v761GateScript = Join-Path $root 'patch_gate_commit_v761.py'
+$v761MapScript = Join-Path $root 'patch_map_click_v761.py'
+$v762GateScript = Join-Path $root 'patch_gate_tick_v762.py'
+$v762MapScript = Join-Path $root 'patch_map_click_v762.py'
+
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$reloadCommit/_temp_player_settlement_v755/patch_main_v756.py" -OutFile $mainPatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v757Commit/_temp_player_settlement_v757/LifecycleSafetyPatches.cs" -OutFile (Join-Path $patchDir 'LifecycleSafetyPatches.cs')
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v759Commit/_temp_player_settlement_v759/patch_gate_workflow_v759.py" -OutFile $v759GatePatchScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v760Commit/_temp_player_settlement_v760/patch_gate_required_v760.py" -OutFile $v760GateRequiredScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v760Commit/_temp_player_settlement_v760/patch_map_click_v760.py" -OutFile $v760MapClickScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v761Commit/_temp_player_settlement_v761/patch_gate_commit_v761.py" -OutFile $v761GateScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v761Commit/_temp_player_settlement_v761/patch_map_click_v761.py" -OutFile $v761MapScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v762Commit/_temp_player_settlement_v762/patch_gate_tick_v762.py" -OutFile $v762GateScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v762Commit/_temp_player_settlement_v762/patch_map_click_v762.py" -OutFile $v762MapScript
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/xmarre/MapPerfFix/$v760Commit/_temp_player_settlement_v760/SaveHandler.cs" -OutFile $saveHandlerPath
+
+python $mainPatchScript (Join-Path $src 'BannerlordPlayerSettlement/Main.cs')
+if ($LASTEXITCODE -ne 0) { throw "Main lifecycle patch failed: $LASTEXITCODE" }
+python $v759GatePatchScript $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.5.9 gate patch failed: $LASTEXITCODE" }
+python $v760GateRequiredScript $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.0 mandatory gate patch failed: $LASTEXITCODE" }
+python $v760MapClickScript $mapPatchPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.0 map click patch failed: $LASTEXITCODE" }
+python $v761GateScript $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.1 gate patch failed: $LASTEXITCODE" }
+python $v761MapScript $mapPatchPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.1 map patch failed: $LASTEXITCODE" }
+python $v762GateScript $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.2 gate tick patch failed: $LASTEXITCODE" }
+python $v762MapScript $mapPatchPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.2 map click suppression patch failed: $LASTEXITCODE" }
+
+Copy-Item (Join-Path $input 'CultureVisualHelper.cs') (Join-Path $patchDir 'CultureVisualHelper.cs') -Force
+python (Join-Path $input 'patch_behavior_769.py') $behaviourPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.9 behavior patch failed: $LASTEXITCODE" }
 python (Join-Path $input 'patch_visual_startup.py') $partyVisualPath
-if ($LASTEXITCODE -ne 0) { throw "PartyVisualPatch startup repair failed: $LASTEXITCODE" }
+if ($LASTEXITCODE -ne 0) { throw "7.6.9 visual startup patch failed: $LASTEXITCODE" }
+python (Join-Path $input 'patch_map_screen_769.py') $mapPatchPath
+if ($LASTEXITCODE -ne 0) { throw "7.6.9 map screen safety patch failed: $LASTEXITCODE" }
 
 $project = Join-Path $src 'BannerlordPlayerSettlement/BannerlordPlayerSettlement.csproj'
 $projectText = Get-Content -Raw $project
-$projectText = $projectText.Replace('<Version>7.6.2</Version>', '<Version>7.6.9</Version>')
+$projectText = [regex]::Replace($projectText, '<Version>[^<]+</Version>', '<Version>7.6.9</Version>', 1)
 Set-Content -Encoding UTF8 $project $projectText
 
-# Regression gates for the exact failure captured by 7.6.8.2 diagnostics.
+# Exact regression gates for the diagnosed visual startup failure and retained release behavior.
 $partyText = Get-Content -Raw $partyVisualPath
+$behaviourText = Get-Content -Raw $behaviourPath
+$mapText = Get-Content -Raw $mapPatchPath
 if ($partyText.Contains('gameEntity.Parent.GetUpgradeLevelOfEntity()')) { throw 'Unsafe map-banner parent dereference remains' }
 if ($partyText.Contains('SetStrategicEntity.Invoke(__instance')) { throw 'Unsafe strategic entity setter invocation remains' }
 if ($partyText.Contains('matricesFrame.ToArray()')) { throw 'Unsafe null siege-frame conversion remains' }
-if (-not $partyText.Contains('return false;') -or -not $partyText.Contains('handlingCustomVisual')) { throw 'Custom visual fail-closed path missing' }
-if (-not $partyText.Contains('SilentException')) { throw 'Silent diagnostic path missing' }
-if (-not (Test-Path (Join-Path $src 'BannerlordPlayerSettlement/Patches/CultureVisualHelper.cs'))) { throw 'Integrated culture visual helper missing' }
+if (-not $partyText.Contains('handlingCustomVisual')) { throw 'Custom visual failure boundary missing' }
+if (-not $partyText.Contains('CultureVisualHelper.TryCopyCreatedSettlementVisual')) { throw 'Created ToR settlement visual fallback missing' }
+if (-not $partyText.Contains('LogManager.Log.SilentException(e);')) { throw 'Non-spamming custom visual diagnostic missing' }
+if (-not $behaviourText.Contains('CultureVisualHelper.TryCopyExistingSettlementVisual')) { throw 'Exact-culture preview visual path missing' }
+if (-not $behaviourText.Contains('castleSettlement.Town.OwnerClan = null;')) { throw 'Castle ownership lifecycle repair missing' }
+if (-not $behaviourText.Contains('townSettlement.Town.OwnerClan = null;')) { throw 'Town ownership lifecycle repair missing' }
+if ($behaviourText.Contains('UpdateSettlementVisualEntity(forward, retry: false);')) { throw 'Cross-culture retry remains' }
+if (-not $mapText.Contains('GetFrameAndVisualOfEngines?.Invoke')) { throw 'Map visual dictionary accessor guard missing' }
+if (Select-String -Path $saveHandlerPath -SimpleMatch 'TryLoadSave') { throw 'Unsafe in-process load remains' }
+if (Select-String -Path $saveHandlerPath -SimpleMatch 'StartNewGame') { throw 'Unsafe campaign restart remains' }
 
 & dotnet build $project -c Beta_Release -p:Platform=x64 --nologo -v:minimal *> (Join-Path $out 'build.log')
 if ($LASTEXITCODE -ne 0) {
-    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 400 | ForEach-Object { Write-Host $_ }
+    Get-Content (Join-Path $out 'build.log') | Select-Object -Last 450 | ForEach-Object { Write-Host $_ }
     throw "dotnet build failed: $LASTEXITCODE"
 }
 
@@ -91,24 +137,31 @@ if (-not $built) { throw 'PlayerSettlement.dll was not produced' }
 $builtPdb = [IO.Path]::ChangeExtension($built.FullName, '.pdb')
 $assemblyVersion = [Reflection.AssemblyName]::GetAssemblyName($built.FullName).Version.ToString()
 if ($assemblyVersion -ne '7.6.9.0') { throw "Unexpected assembly version: $assemblyVersion" }
+$references = [Reflection.AssemblyName]::GetAssemblyName($built.FullName) | Out-Null
+$loadedAssembly = [Reflection.Assembly]::ReflectionOnlyLoadFrom($built.FullName)
+if ($loadedAssembly.GetReferencedAssemblies().Name -contains 'PlayerSettlementCultureVisuals') {
+    throw 'External PlayerSettlementCultureVisuals assembly reference remains'
+}
 
 Copy-Item $built.FullName (Join-Path $out 'PlayerSettlement.dll') -Force
 if (Test-Path $builtPdb) { Copy-Item $builtPdb (Join-Path $out 'PlayerSettlement.pdb') -Force }
 Copy-Item $partyVisualPath (Join-Path $out 'PartyVisualPatch.cs') -Force
-Copy-Item (Join-Path $src 'BannerlordPlayerSettlement/Patches/CultureVisualHelper.cs') (Join-Path $out 'CultureVisualHelper.cs') -Force
-Copy-Item (Join-Path $src 'BannerlordPlayerSettlement/Behaviours/PlayerSettlementBehaviour.cs') (Join-Path $out 'PlayerSettlementBehaviour.cs') -Force
+Copy-Item $behaviourPath (Join-Path $out 'PlayerSettlementBehaviour.cs') -Force
+Copy-Item $mapPatchPath (Join-Path $out 'MapScreenPatch.cs') -Force
+Copy-Item $saveHandlerPath (Join-Path $out 'SaveHandler.cs') -Force
+Copy-Item (Join-Path $patchDir 'CultureVisualHelper.cs') (Join-Path $out 'CultureVisualHelper.cs') -Force
 Copy-Item $project (Join-Path $out 'BannerlordPlayerSettlement.csproj') -Force
 git -C $src diff | Set-Content -Encoding UTF8 (Join-Path $out 'source_7.6.9.patch')
 
 $dllHash = (Get-FileHash $built.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
 $pdbHash = if (Test-Path $builtPdb) { (Get-FileHash $builtPdb -Algorithm SHA256).Hash.ToLowerInvariant() } else { '<not produced>' }
 @"
-Version=7.6.9.0
+Version=$assemblyVersion
 UpstreamCommit=$upstreamCommit
-SourceInputSHA256=$actualInputHash
+ValidatedNativePatchSHA256=$actualNativePatchHash
 PlayerSettlementDLL_SHA256=$dllHash
 PlayerSettlementPDB_SHA256=$pdbHash
-Fix=SettlementVisual.OnStartup null-safety; integrated culture visual helper; no external helper assembly dependency
+Fix=SettlementVisual.OnStartup null-safety; created ToR visual fallback; exact-culture preview; ownership lifecycle; integrated culture helper
 "@ | Set-Content -Encoding UTF8 (Join-Path $out 'BUILD_INFO_7.6.9.txt')
 
 Write-Host "PlayerSettlement.dll version: $assemblyVersion"

--- a/_ps_visual_startup_fix_769/build.ps1
+++ b/_ps_visual_startup_fix_769/build.ps1
@@ -1,21 +1,31 @@
 $ErrorActionPreference = 'Stop'
 
 $workspace = $env:GITHUB_WORKSPACE
-$inputZip = Join-Path $workspace '_ps_visual_startup_fix_769/PlayerSettlement_7.6.9_SOURCE_INPUT.zip'
-$expectedInputHash = 'f298b5c9b8ea961845cf15d45b5a2985f2e0b5cfcec7c497c47be6f880f87785'
-$actualInputHash = (Get-FileHash $inputZip -Algorithm SHA256).Hash.ToLowerInvariant()
-if ($actualInputHash -ne $expectedInputHash) {
-    throw "SOURCE INPUT SHA-256 mismatch. Expected=$expectedInputHash Actual=$actualInputHash"
+$input = Join-Path $workspace '_ps_visual_startup_fix_769/input'
+$expectedHashes = @{
+    'source.patch' = 'ac71cb6b31ef2fae332949164b1ad2d286169637d8e3818cbe16974edf69fec5'
+    'PlayerSettlementBehaviour.cs' = 'd61dfc9a8773808219a7c864cc0f235a2266e4f337cbffaff8232d8df56d6323'
+    'MapScreenPatch.cs' = '3af8bffe857ffd64bc5ffc5611eabd1f3d2d22c596821665d1480a7877c12641'
+    'SaveHandler.cs' = '126c75a557265c6619b7d7cb09e3d322316d3032a67f84359cd15153ac284b9d'
+    'CultureVisualHelper.cs' = 'bba0336eab51535ecfd594098df09bf94827b9b7f95f29c5c54294a2440c0e62'
+    'patch_visual_startup.py' = 'de1ec95b9e121ba72767c6b8d98e216afb77685e58a739a8dde65b45c1df1824'
 }
-Write-Host "SOURCE INPUT SHA-256 verified: $actualInputHash"
+foreach ($entry in $expectedHashes.GetEnumerator()) {
+    $path = Join-Path $input $entry.Key
+    if (-not (Test-Path $path)) { throw "SOURCE INPUT missing: $($entry.Key)" }
+    $actual = (Get-FileHash $path -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $entry.Value) {
+        throw "SOURCE INPUT SHA-256 mismatch for $($entry.Key). Expected=$($entry.Value) Actual=$actual"
+    }
+    Write-Host "SOURCE INPUT SHA-256 verified: $($entry.Key) $actual"
+}
+$actualInputHash = ($expectedHashes.GetEnumerator() | Sort-Object Key | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ';'
 
 $root = Join-Path $workspace '_ps_visual_startup_fix_769_build'
-$input = Join-Path $root 'input'
 $src = Join-Path $root 'source'
 $out = Join-Path $root 'out'
 Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
-New-Item -ItemType Directory -Force -Path $root,$input,$out | Out-Null
-Expand-Archive -Path $inputZip -DestinationPath $input -Force
+New-Item -ItemType Directory -Force -Path $root,$out | Out-Null
 
 $upstreamCommit = '52d86c7480778afb83e476ac742895f73fbf6d7f'
 git clone https://github.com/BOTLANNER/BannerlordPlayerSettlement.git $src

--- a/_ps_visual_startup_fix_769/input/CultureVisualHelper.cs
+++ b/_ps_visual_startup_fix_769/input/CultureVisualHelper.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Engine;
+using TaleWorlds.Library;
+
+namespace BannerlordPlayerSettlement.Patches
+{
+    public static class CultureVisualHelper
+    {
+        private const string TorTemplateMarker = "_ToR";
+        private const string PlayerSettlementPrefix = "player_settlement_";
+
+        public static GameEntity TryCopyExistingSettlementVisual(
+            Scene scene,
+            string cultureId,
+            int settlementType,
+            string templateId,
+            string entityId,
+            Vec2 position)
+        {
+            if (scene == null ||
+                string.IsNullOrEmpty(cultureId) ||
+                !IsTorIdentifier(templateId))
+            {
+                return null;
+            }
+
+            return CopyMatchingVisual(
+                scene,
+                cultureId,
+                settlementType,
+                templateId,
+                entityId,
+                position);
+        }
+
+        public static GameEntity TryCopyCreatedSettlementVisual(
+            Scene scene,
+            string settlementId,
+            Vec2 position)
+        {
+            if (scene == null || !IsTorIdentifier(settlementId))
+                return null;
+
+            Settlement target = Settlement.Find(settlementId);
+            if (target == null || target.Culture == null)
+                return null;
+
+            int settlementType = target.IsTown ? 1 : target.IsVillage ? 2 : target.IsCastle ? 3 : 0;
+            if (settlementType == 0)
+                return null;
+
+            return CopyMatchingVisual(
+                scene,
+                target.Culture.StringId,
+                settlementType,
+                settlementId,
+                settlementId,
+                position);
+        }
+
+        private static GameEntity CopyMatchingVisual(
+            Scene scene,
+            string cultureId,
+            int settlementType,
+            string variantKey,
+            string entityId,
+            Vec2 position)
+        {
+            var candidates = new List<Settlement>();
+            foreach (Settlement settlement in Settlement.All)
+            {
+                if (!IsMatchingSource(settlement, cultureId, settlementType))
+                    continue;
+
+                GameEntity source = scene.GetCampaignEntityWithName(settlement.StringId);
+                if (source != null)
+                    candidates.Add(settlement);
+            }
+
+            if (candidates.Count == 0 && (settlementType == 1 || settlementType == 3))
+            {
+                foreach (Settlement settlement in Settlement.All)
+                {
+                    if (!IsSameCultureSource(settlement, cultureId) ||
+                        (!settlement.IsTown && !settlement.IsCastle))
+                    {
+                        continue;
+                    }
+
+                    GameEntity source = scene.GetCampaignEntityWithName(settlement.StringId);
+                    if (source != null)
+                        candidates.Add(settlement);
+                }
+            }
+
+            if (candidates.Count == 0)
+                return null;
+
+            int startIndex = GetVariantIndex(variantKey, candidates.Count);
+            for (int offset = 0; offset < candidates.Count; offset++)
+            {
+                Settlement settlement = candidates[(startIndex + offset) % candidates.Count];
+                GameEntity source = scene.GetCampaignEntityWithName(settlement.StringId);
+                if (source == null)
+                    continue;
+
+                GameEntity copy = GameEntity.CopyFromPrefab(source);
+                if (copy == null)
+                    continue;
+
+                copy.Name = entityId;
+                Vec3 position3D = new Vec3(position.x, position.y, 0f, -1f);
+                position3D.z = scene.GetGroundHeightAtPosition(
+                    position.ToVec3(0f),
+                    (BodyFlags)544321929);
+                copy.SetLocalPosition(position3D);
+                return copy;
+            }
+
+            return null;
+        }
+
+        private static bool IsMatchingSource(
+            Settlement settlement,
+            string cultureId,
+            int settlementType)
+        {
+            if (!IsSameCultureSource(settlement, cultureId))
+                return false;
+
+            if (settlementType == 1)
+                return settlement.IsTown;
+            if (settlementType == 2)
+                return settlement.IsVillage;
+            if (settlementType == 3)
+                return settlement.IsCastle;
+
+            return false;
+        }
+
+        private static bool IsSameCultureSource(Settlement settlement, string cultureId)
+        {
+            if (settlement == null || settlement.Culture == null || !settlement.IsVisible)
+                return false;
+
+            if (!string.Equals(
+                    settlement.Culture.StringId,
+                    cultureId,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return string.IsNullOrEmpty(settlement.StringId) ||
+                   !settlement.StringId.StartsWith(
+                       PlayerSettlementPrefix,
+                       StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsTorIdentifier(string value)
+        {
+            return !string.IsNullOrEmpty(value) &&
+                   value.IndexOf(TorTemplateMarker, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static int GetVariantIndex(string value, int candidateCount)
+        {
+            if (candidateCount <= 1 || string.IsNullOrEmpty(value))
+                return 0;
+
+            const string marker = "_variant_";
+            int markerIndex = value.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (markerIndex < 0)
+                return 0;
+
+            int start = markerIndex + marker.Length;
+            int end = start;
+            while (end < value.Length && char.IsDigit(value[end]))
+                end++;
+
+            int variant;
+            if (end <= start || !int.TryParse(value.Substring(start, end - start), out variant))
+                return 0;
+
+            return Math.Max(0, variant - 1) % candidateCount;
+        }
+    }
+}

--- a/_ps_visual_startup_fix_769/input/MapScreenPatch.cs
+++ b/_ps_visual_startup_fix_769/input/MapScreenPatch.cs
@@ -1,0 +1,130 @@
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+
+using BannerlordPlayerSettlement.Behaviours;
+using BannerlordPlayerSettlement.Extensions;
+using BannerlordPlayerSettlement.UI.Viewmodels;
+
+using HarmonyLib;
+
+using SandBox.View.Map;
+using SandBox.View.Map.Visuals;
+
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Siege;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+
+namespace BannerlordPlayerSettlement.Patches
+{
+
+    [HarmonyPatch(typeof(MapScreen))]
+    public static class MapScreenPatch
+    {
+
+        static MethodInfo GetFrameAndVisualOfEngines = AccessTools.Property(typeof(MapScreen), "FrameAndVisualOfEngines").GetMethod;
+        public static Dictionary<UIntPtr, Tuple<MatrixFrame, SettlementVisual>> FrameAndVisualOfEngines()
+        {
+            return (Dictionary<UIntPtr, Tuple<MatrixFrame, SettlementVisual>>) GetFrameAndVisualOfEngines.Invoke(null, null);
+        }
+
+
+        static MethodInfo GetDesiredDecalColorMethod = AccessTools.Method(typeof(MapScreen), "GetDesiredDecalColor");
+
+        public static uint GetDesiredDecalColor(this MapScreen mapScreen, bool isPrepOver, bool isHovered, bool isEnemy, bool isEmpty, bool isPlayerLeader)
+        {
+            return (uint) GetDesiredDecalColorMethod.Invoke(mapScreen, new object[] { isPrepOver, isHovered, isEnemy, isEmpty, isPlayerLeader });
+        }
+
+
+        static MethodInfo GetDesiredMaterialNameMethod = AccessTools.Method(typeof(MapScreen), "GetDesiredMaterialName");
+
+        public static string GetDesiredMaterialName(this MapScreen mapScreen, bool isRanged, bool isAttacker, bool isEmpty, bool isTower)
+        {
+            return (string) GetDesiredMaterialNameMethod.Invoke(mapScreen, new object[] { isRanged, isAttacker, isEmpty, isTower });
+        }
+
+        static MethodInfo IsEscapedMethod = AccessTools.Method(typeof(MapView), "IsEscaped") ?? AccessTools.DeclaredMethod(typeof(MapView), "IsEscaped");
+
+        static bool CheckIsEscaped(this MapView mapView)
+        {
+            try
+            {
+                return (bool) IsEscapedMethod.Invoke(mapView, new object[] { });
+            }
+            catch (Exception e)
+            {
+                // No logging, this is default behaviour
+                return false;
+            }
+        }
+
+        static MapScreenPatch()
+        {
+            Main.Harmony?.Patch(AccessTools.DeclaredMethod(typeof(MapScreen), "TaleWorlds.CampaignSystem.GameState.IMapStateHandler.AfterWaitTick"), prefix: new HarmonyMethod(typeof(MapScreenPatch), nameof(AfterWaitTick)));
+        }
+
+        public static bool AfterWaitTick(ref MapScreen __instance, ref MapViewsContainer ____mapViewsContainer, float dt)
+        {
+            if (__instance.SceneLayer.Input.IsHotKeyReleased("ToggleEscapeMenu") &&
+                    PlayerSettlementBehaviour.Instance != null &&
+                    (PlayerSettlementBehaviour.Instance.IsPlacingSettlement ||
+                    PlayerSettlementBehaviour.Instance.IsPlacingPort ||
+                        PlayerSettlementBehaviour.Instance.IsPlacingGate))
+            {
+                if (!____mapViewsContainer.IsThereAnyViewIsEscaped())
+                {
+                    if (PlayerSettlementBehaviour.Instance.IsPlacingGate || PlayerSettlementBehaviour.Instance.IsPlacingPort)
+                    {
+                        PlayerSettlementBehaviour.Instance.RefreshVisualSelection();
+                        return false;
+                    }
+                    PlayerSettlementBehaviour.Instance.Reset();
+                    MapBarExtensionVM.Current?.OnRefresh();
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(HandleLeftMouseButtonClick))]
+        public static bool HandleLeftMouseButtonClick(ref MapScreen __instance, MapEntityVisual visualOfSelectedEntity, CampaignVec2 intersectionPoint, PathFaceRecord mouseOverFaceIndex, bool isDoubleClick)
+        {
+
+            PlayerSettlementBehaviour behaviour = PlayerSettlementBehaviour.Instance;
+            if (!__instance.SceneLayer.Input.GetIsMouseActive() || behaviour == null)
+            {
+                return true;
+            }
+
+            // The placement behavior now detects the mouse-release inside the same map tick that
+            // calculates the preview frame. This prefix only suppresses Bannerlord's normal map
+            // selection/click handling so it cannot select the ghost or newly created settlement.
+            if (behaviour.IsPlacingPort || behaviour.IsPlacingGate || behaviour.IsPlacingSettlement)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(CheckCursorState))]
+        public static void CheckCursorState(ref MapScreen __instance)
+        {
+            if (__instance.SceneLayer.Input.GetIsMouseActive() && PlayerSettlementBehaviour.Instance != null)
+            {
+                if (PlayerSettlementBehaviour.Instance.IsPlacingPort || PlayerSettlementBehaviour.Instance.IsPlacingGate || PlayerSettlementBehaviour.Instance.IsPlacingSettlement)
+                {
+                    __instance.SceneLayer.ActiveCursor = PlayerSettlementBehaviour.Instance.PlacementSupported ? TaleWorlds.ScreenSystem.CursorType.Default : TaleWorlds.ScreenSystem.CursorType.Disabled;
+                }
+            }
+        }
+    }
+}

--- a/_ps_visual_startup_fix_769/input/SaveHandler.cs
+++ b/_ps_visual_startup_fix_769/input/SaveHandler.cs
@@ -1,0 +1,214 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+using BannerlordPlayerSettlement.Behaviours;
+
+using HarmonyLib;
+
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using TaleWorlds.SaveSystem;
+
+namespace BannerlordPlayerSettlement
+{
+    public sealed class SaveHandler
+    {
+        public enum SaveMechanism
+        {
+            Overwrite = 0,
+            Auto = 1,
+            Temporary = 2
+        }
+
+        private static readonly SaveHandler _instance = new SaveHandler();
+        public static SaveHandler Instance => _instance;
+
+        private static readonly PropertyInfo ActiveSaveSlotNameProp = AccessTools.Property(typeof(MBSaveLoad), "ActiveSaveSlotName");
+        private static readonly MethodInfo GetNextAvailableSaveNameMethod = AccessTools.Method(typeof(MBSaveLoad), "GetNextAvailableSaveName");
+
+        private bool _saveInProgress;
+        private Action<SaveMechanism, string>? _afterSave;
+        private SaveMechanism _requestedMechanism;
+        private string? _requestedSaveName;
+
+        public static void SaveLoad(SaveMechanism saveMechanism = SaveMechanism.Overwrite, Action<SaveMechanism, string>? afterSave = null)
+        {
+            Instance.SaveAndContinue(saveMechanism, afterSave);
+        }
+
+        public static void SaveOnly(bool overwrite = true)
+        {
+            Instance.Save(overwrite);
+        }
+
+        public void SaveAndContinue(SaveMechanism saveMechanism = SaveMechanism.Overwrite, Action<SaveMechanism, string>? afterSave = null)
+        {
+            if (_saveInProgress)
+            {
+                WriteTransitionLog("Save request ignored because another placement save is active");
+                return;
+            }
+
+            if (Campaign.Current?.SaveHandler == null)
+            {
+                WriteTransitionLog("Save request ignored because Campaign.SaveHandler is unavailable");
+                return;
+            }
+
+            try
+            {
+                PlayerSettlementBehaviour.Instance?.Reset();
+                WriteTransitionLog("Completed placement state cleared before save");
+            }
+            catch (Exception e)
+            {
+                WriteTransitionLog("Placement reset before save failed: " + e);
+            }
+
+            string activeName = ActiveSaveSlotNameProp.GetValue(null) as string;
+            if (string.IsNullOrWhiteSpace(activeName))
+            {
+                activeName = GetNextAvailableSaveNameMethod.Invoke(null, Array.Empty<object>()) as string;
+                if (string.IsNullOrWhiteSpace(activeName))
+                {
+                    activeName = "PlayerSettlement";
+                }
+                ActiveSaveSlotNameProp.SetValue(null, activeName);
+            }
+
+            string targetName;
+            SaveMechanism effectiveMechanism;
+            if (saveMechanism == SaveMechanism.Auto)
+            {
+                targetName = activeName + new TextObject("{=player_settlement_n_02} (auto)").ToString();
+                effectiveMechanism = SaveMechanism.Auto;
+            }
+            else
+            {
+                targetName = activeName;
+                effectiveMechanism = SaveMechanism.Overwrite;
+            }
+
+            _saveInProgress = true;
+            _afterSave = afterSave;
+            _requestedMechanism = effectiveMechanism;
+            _requestedSaveName = targetName;
+
+            CampaignEvents.OnSaveOverEvent.ClearListeners(this);
+            CampaignEvents.OnSaveOverEvent.AddNonSerializedListener(this, OnSaveCompleted);
+
+            WriteTransitionLog($"Saving placement without in-process reload: requested={saveMechanism}, effective={effectiveMechanism}, target={targetName}");
+
+            try
+            {
+                Campaign.Current.SaveHandler.SaveAs(targetName);
+            }
+            catch (Exception e)
+            {
+                WriteTransitionLog("Placement save request failed: " + e);
+                ResetPendingState();
+                throw;
+            }
+        }
+
+        public void Save(bool overwrite = true)
+        {
+            string activeName = ActiveSaveSlotNameProp.GetValue(null) as string;
+            if (string.IsNullOrWhiteSpace(activeName))
+            {
+                activeName = GetNextAvailableSaveNameMethod.Invoke(null, Array.Empty<object>()) as string;
+                if (string.IsNullOrWhiteSpace(activeName))
+                {
+                    activeName = "PlayerSettlement";
+                }
+                ActiveSaveSlotNameProp.SetValue(null, activeName);
+            }
+
+            string targetName = overwrite
+                ? activeName
+                : activeName + new TextObject("{=player_settlement_n_02} (auto)").ToString();
+            Campaign.Current.SaveHandler.SaveAs(targetName);
+        }
+
+        private void OnSaveCompleted(bool successful, string writtenName)
+        {
+            CampaignEvents.OnSaveOverEvent.ClearListeners(this);
+            WriteTransitionLog($"Placement save completed: success={successful}, written={writtenName}");
+
+            Action<SaveMechanism, string>? callback = _afterSave;
+            SaveMechanism mechanism = _requestedMechanism;
+            string requestedName = _requestedSaveName ?? writtenName;
+            ResetPendingState(clearListener: false);
+
+            if (!successful)
+            {
+                MBInformationManager.AddQuickInformation(
+                    new TextObject("{=!}Player Settlement could not save the newly created settlement."),
+                    0,
+                    Hero.MainHero?.CharacterObject);
+                return;
+            }
+
+            try
+            {
+                ActiveSaveSlotNameProp.SetValue(null, string.IsNullOrWhiteSpace(writtenName) ? requestedName : writtenName);
+            }
+            catch (Exception e)
+            {
+                WriteTransitionLog("Could not update active save slot: " + e);
+            }
+
+            try
+            {
+                callback?.Invoke(mechanism, writtenName);
+            }
+            catch (Exception e)
+            {
+                WriteTransitionLog("afterSave callback failed: " + e);
+            }
+
+            MBInformationManager.AddQuickInformation(
+                new TextObject("{=!}Settlement created and saved. Automatic in-process reload is disabled for Bannerlord 1.3.15 stability."),
+                0,
+                Hero.MainHero?.CharacterObject);
+        }
+
+        public void OnApplicationTick(float dt)
+        {
+        }
+
+        private void ResetPendingState(bool clearListener = true)
+        {
+            if (clearListener)
+            {
+                try { CampaignEvents.OnSaveOverEvent.ClearListeners(this); } catch { }
+            }
+
+            _saveInProgress = false;
+            _afterSave = null;
+            _requestedSaveName = null;
+            _requestedMechanism = SaveMechanism.Overwrite;
+        }
+
+        private static void WriteTransitionLog(string message)
+        {
+            try
+            {
+                string userDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                    "Mount and Blade II Bannerlord");
+                string directory = Path.Combine(userDir, "Configs", "BannerlordPlayerSettlement");
+                Directory.CreateDirectory(directory);
+                File.AppendAllText(
+                    Path.Combine(directory, "save_transition.log"),
+                    DateTime.UtcNow.ToString("O") + " | " + message + Environment.NewLine);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/_ps_visual_startup_fix_769/input/patch_behavior_769.py
+++ b/_ps_visual_startup_fix_769/input/patch_behavior_769.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding='utf-8-sig')
+
+def replace_once(old: str, new: str, label: str):
+    global source
+    count = source.count(old)
+    if count != 1:
+        raise RuntimeError(f'{label}: expected 1 marker, found {count}')
+    source = source.replace(old, new, 1)
+
+replace_once(
+'''                Exception addError = null;
+                settlementVisualEntity = Campaign.Current.MapSceneWrapper.AddPrefabEntityToMapScene(ref mapScene, ref entityId, ref position2D, ref prefabId, (ex) =>
+                {
+                    addError = ex;
+                });
+''',
+'''                Exception addError = null;
+                settlementVisualEntity = CultureVisualHelper.TryCopyExistingSettlementVisual(
+                    mapScene,
+                    template.Culture,
+                    template.Type,
+                    template.Id,
+                    entityId,
+                    position2D);
+
+                if (settlementVisualEntity == null)
+                {
+                    settlementVisualEntity = Campaign.Current.MapSceneWrapper.AddPrefabEntityToMapScene(ref mapScene, ref entityId, ref position2D, ref prefabId, (ex) =>
+                    {
+                        addError = ex;
+                    });
+                }
+''',
+'exact-culture visual fallback')
+
+replace_once(
+'''                if (settlementVisualEntity == null)
+                {
+                    Reset();
+                }
+                settlementVisualEntityChildren.Clear();
+''',
+'''                if (settlementVisualEntity == null)
+                {
+                    LogManager.EventTracer.Trace($"Settlement visual prefab returned null: {prefabId}");
+                    // A failed visual may not advance into another culture. The TOR-specific
+                    // helper already attempted an exact-culture live visual before this branch.
+                    Reset();
+                    return;
+                }
+                settlementVisualEntityChildren.Clear();
+''',
+'null visual cancellation')
+
+replace_once(
+'''                if (retry)
+                {
+                    // Retry once without allowing another retry to avoid stackoverflow loops
+                    UpdateSettlementVisualEntity(forward, retry: false);
+                }
+                else if ((e is AccessViolationException || previousVisualUpdateException is AccessViolationException))
+''',
+'''                if ((e is AccessViolationException || previousVisualUpdateException is AccessViolationException))
+''',
+'cross-culture retry removal')
+
+replace_once(
+'''                        castleSettlement.Town.OwnerClan = Hero.MainHero.Clan;
+''',
+'''                        castleSettlement.Town.OwnerClan = null;
+                        castleSettlement.Town.OwnerClan = Clan.PlayerClan;
+''',
+'castle ownership lifecycle')
+
+replace_once(
+'''                        townSettlement.Town.OwnerClan = Hero.MainHero.Clan;
+''',
+'''                        townSettlement.Town.OwnerClan = null;
+                        townSettlement.Town.OwnerClan = Clan.PlayerClan;
+''',
+'town ownership lifecycle')
+
+path.write_text(source, encoding='utf-8', newline='\n')

--- a/_ps_visual_startup_fix_769/input/patch_map_screen_769.py
+++ b/_ps_visual_startup_fix_769/input/patch_map_screen_769.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding='utf-8-sig')
+old = '''        static MethodInfo GetFrameAndVisualOfEngines = AccessTools.Property(typeof(MapScreen), "FrameAndVisualOfEngines").GetMethod;
+        public static Dictionary<UIntPtr, Tuple<MatrixFrame, SettlementVisual>> FrameAndVisualOfEngines()
+        {
+            return (Dictionary<UIntPtr, Tuple<MatrixFrame, SettlementVisual>>) GetFrameAndVisualOfEngines.Invoke(null, null);
+        }
+'''
+new = '''        static readonly MethodInfo GetFrameAndVisualOfEngines = AccessTools.Property(typeof(MapScreen), "FrameAndVisualOfEngines")?.GetGetMethod(true);
+        public static Dictionary<UIntPtr, Tuple<MatrixFrame, SettlementVisual>> FrameAndVisualOfEngines()
+        {
+            return GetFrameAndVisualOfEngines?.Invoke(null, null) as Dictionary<UIntPtr, Tuple<MatrixFrame, SettlementVisual>>;
+        }
+'''
+if source.count(old) != 1:
+    raise RuntimeError(f'FrameAndVisualOfEngines marker count: {source.count(old)}')
+source = source.replace(old, new, 1)
+path.write_text(source, encoding='utf-8', newline='\n')

--- a/_ps_visual_startup_fix_769/input/patch_visual_startup.py
+++ b/_ps_visual_startup_fix_769/input/patch_visual_startup.py
@@ -1,0 +1,268 @@
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding='utf-8-sig')
+
+def replace_once(old: str, new: str, label: str):
+    global source
+    if old not in source:
+        raise RuntimeError(f'marker not found: {label}')
+    source = source.replace(old, new, 1)
+
+replace_once(
+'''        static MethodInfo SetStrategicEntity = AccessTools.Property(typeof(SettlementVisual), "StrategicEntity").SetMethod;
+        static MethodInfo SetTownPhysicalEntities = AccessTools.Property(typeof(SettlementVisual), "TownPhysicalEntities").SetMethod;
+        static MethodInfo SetCircleLocalFrame = AccessTools.Property(typeof(SettlementVisual), "CircleLocalFrame").SetMethod;
+
+        static MethodInfo GetMapScene = AccessTools.Property(typeof(SettlementVisual), "MapScene").GetMethod;
+''',
+'''        static readonly PropertyInfo StrategicEntityProperty = AccessTools.Property(typeof(SettlementVisual), "StrategicEntity");
+        static readonly MethodInfo SetStrategicEntity = StrategicEntityProperty?.GetSetMethod(true);
+        static readonly FieldInfo StrategicEntityField = AccessTools.Field(typeof(SettlementVisual), "<StrategicEntity>k__BackingField")
+            ?? AccessTools.Field(typeof(SettlementVisual), "_strategicEntity");
+
+        static readonly PropertyInfo TownPhysicalEntitiesProperty = AccessTools.Property(typeof(SettlementVisual), "TownPhysicalEntities");
+        static readonly MethodInfo SetTownPhysicalEntities = TownPhysicalEntitiesProperty?.GetSetMethod(true);
+        static readonly FieldInfo TownPhysicalEntitiesField = AccessTools.Field(typeof(SettlementVisual), "<TownPhysicalEntities>k__BackingField")
+            ?? AccessTools.Field(typeof(SettlementVisual), "_townPhysicalEntities");
+
+        static readonly PropertyInfo CircleLocalFrameProperty = AccessTools.Property(typeof(SettlementVisual), "CircleLocalFrame");
+        static readonly MethodInfo SetCircleLocalFrame = CircleLocalFrameProperty?.GetSetMethod(true);
+        static readonly FieldInfo CircleLocalFrameField = AccessTools.Field(typeof(SettlementVisual), "<CircleLocalFrame>k__BackingField")
+            ?? AccessTools.Field(typeof(SettlementVisual), "_circleLocalFrame");
+
+        static readonly MethodInfo GetMapScene = AccessTools.Property(typeof(SettlementVisual), "MapScene")?.GetGetMethod(true);
+''',
+'accessor hardening')
+
+replace_once(
+'''        public static Scene MapScene(this SettlementVisual __instance)
+        {
+            return (Scene) GetMapScene.Invoke(__instance, null);
+        }
+''',
+'''        public static Scene MapScene(this SettlementVisual __instance)
+        {
+            if (__instance == null)
+            {
+                return null;
+            }
+
+            if (GetMapScene != null)
+            {
+                return GetMapScene.Invoke(__instance, null) as Scene;
+            }
+
+            return (Campaign.Current?.MapSceneWrapper as MapScene)?.Scene;
+        }
+
+        private static void AssignStrategicEntity(SettlementVisual visual, GameEntity entity)
+        {
+            if (visual == null)
+            {
+                return;
+            }
+
+            if (SetStrategicEntity != null)
+            {
+                SetStrategicEntity.Invoke(visual, new object[] { entity });
+                return;
+            }
+
+            StrategicEntityField?.SetValue(visual, entity);
+        }
+
+        private static void AssignTownPhysicalEntities(SettlementVisual visual, List<GameEntity> entities)
+        {
+            if (SetTownPhysicalEntities != null)
+            {
+                SetTownPhysicalEntities.Invoke(visual, new object[] { entities });
+                return;
+            }
+
+            TownPhysicalEntitiesField?.SetValue(visual, entities);
+        }
+
+        private static void AssignCircleLocalFrame(SettlementVisual visual, MatrixFrame frame)
+        {
+            if (SetCircleLocalFrame != null)
+            {
+                SetCircleLocalFrame.Invoke(visual, new object[] { frame });
+                return;
+            }
+
+            CircleLocalFrameField?.SetValue(visual, frame);
+        }
+''',
+'accessor helpers')
+
+replace_once(
+'''        public static bool OnStartup(ref SettlementVisual __instance, ref Dictionary<int, List<GameEntity>> ____gateBannerEntitiesWithLevels)
+        {
+            try
+            {
+                OverwriteSettlementItem? overwriteItem = null;
+                bool isPlayerSettlement = (__instance.MapEntity != null && __instance.MapEntity.Settlement.IsPlayerBuilt());
+                bool isOverwrite = (__instance.MapEntity != null && __instance.MapEntity.Settlement.IsOverwritten(out overwriteItem));
+''',
+'''        public static bool OnStartup(ref SettlementVisual __instance, ref Dictionary<int, List<GameEntity>> ____gateBannerEntitiesWithLevels)
+        {
+            bool handlingCustomVisual = false;
+            try
+            {
+                var mapVisual = __instance as MapEntityVisual<PartyBase>;
+                var mapEntity = mapVisual?.MapEntity;
+                var settlement = mapEntity?.Settlement;
+                if (settlement == null)
+                {
+                    return true;
+                }
+
+                OverwriteSettlementItem? overwriteItem = null;
+                bool isPlayerSettlement = settlement.IsPlayerBuilt();
+                bool isOverwrite = settlement.IsOverwritten(out overwriteItem);
+                handlingCustomVisual = isPlayerSettlement || isOverwrite;
+''',
+'custom visual preconditions')
+
+replace_once(
+'''                    SetStrategicEntity.Invoke(__instance, new object[] { __instance.MapScene().GetCampaignEntityWithName(__instance.MapEntity.Id) });
+''',
+'''                    var scene = __instance.MapScene();
+                    AssignStrategicEntity(__instance,
+                        scene?.GetCampaignEntityWithName(mapEntity.Id)
+                        ?? scene?.GetCampaignEntityWithName(settlement.StringId));
+''',
+'initial strategic entity assignment')
+
+replace_once(
+'''                    IMapScene mapSceneWrapper = Campaign.Current.MapSceneWrapper;
+                    string stringId = (__instance as MapEntityVisual<PartyBase>).MapEntity.Settlement.StringId;
+                    CampaignVec2 position = (__instance as MapEntityVisual<PartyBase>).MapEntity.Settlement.Position;
+                    mapSceneWrapper.AddNewEntityToMapScene(stringId, in position);
+                    SetStrategicEntity.Invoke(__instance, new object[] { __instance.MapScene().GetCampaignEntityWithName((__instance as MapEntityVisual<PartyBase>).MapEntity.Id) });
+                }
+''',
+'''                    IMapScene mapSceneWrapper = Campaign.Current?.MapSceneWrapper;
+                    string stringId = settlement.StringId;
+                    CampaignVec2 position = settlement.Position;
+                    mapSceneWrapper?.AddNewEntityToMapScene(stringId, in position);
+                    var scene = __instance.MapScene();
+                    AssignStrategicEntity(__instance,
+                        scene?.GetCampaignEntityWithName(mapEntity.Id)
+                        ?? scene?.GetCampaignEntityWithName(stringId));
+                }
+
+                if (__instance.StrategicEntity == null)
+                {
+                    LogManager.Log.Info($"Player settlement visual startup skipped because no strategic entity could be resolved for '{settlement.StringId}'.");
+                    return false;
+                }
+''',
+'strategic entity fallback')
+
+source = source.replace('(__instance as MapEntityVisual<PartyBase>).MapEntity.Settlement', 'settlement')
+source = source.replace('(__instance as MapEntityVisual<PartyBase>).MapEntity.IsSettlement', 'mapEntity.IsSettlement')
+source = source.replace('(__instance as MapEntityVisual<PartyBase>).MapEntity.IsVisible', 'mapEntity.IsVisible')
+source = source.replace('__instance.MapEntity.Settlement', 'settlement')
+
+replace_once(
+'''                    PopulateSiegeEngineFrameListsFromChildren.Invoke(__instance, new object[] { gameEntities });
+                    UpdateDefenderSiegeEntitiesCache.Invoke(__instance, null);
+                    SetTownPhysicalEntities.Invoke(__instance, new object[] { gameEntities.FindAll((GameEntity x) => x.HasTag("bo_town")) });
+''',
+'''                    PopulateSiegeEngineFrameListsFromChildren?.Invoke(__instance, new object[] { gameEntities });
+                    UpdateDefenderSiegeEntitiesCache?.Invoke(__instance, null);
+                    AssignTownPhysicalEntities(__instance, gameEntities.FindAll((GameEntity x) => x != null && x.HasTag("bo_town")));
+''',
+'fortification reflection guards')
+
+replace_once(
+'''                        int upgradeLevelOfEntity = gameEntity.Parent.GetUpgradeLevelOfEntity();
+                        if (upgradeLevelOfEntity != 0)
+                        {
+                            nums[upgradeLevelOfEntity].Add(gameEntity);
+                        }
+''',
+'''                        int upgradeLevelOfEntity = gameEntity.Parent?.GetUpgradeLevelOfEntity() ?? 0;
+                        if (upgradeLevelOfEntity != 0 && nums.TryGetValue(upgradeLevelOfEntity, out var levelEntities))
+                        {
+                            levelEntities.Add(gameEntity);
+                        }
+''',
+'banner parent and level guard')
+
+replace_once(
+'''                        Campaign.Current.MapSceneWrapper.GetSiegeCampFrames(settlement, out matricesFrame, out matricesFrame1);
+                        settlement.Town.BesiegerCampPositions1 = matricesFrame.ToArray();
+                        settlement.Town.BesiegerCampPositions2 = matricesFrame1.ToArray();
+''',
+'''                        Campaign.Current?.MapSceneWrapper?.GetSiegeCampFrames(settlement, out matricesFrame, out matricesFrame1);
+                        if (settlement.Town != null)
+                        {
+                            settlement.Town.BesiegerCampPositions1 = (matricesFrame ?? new List<MatrixFrame>()).ToArray();
+                            settlement.Town.BesiegerCampPositions2 = (matricesFrame1 ?? new List<MatrixFrame>()).ToArray();
+                        }
+''',
+'siege camp frame null guards')
+
+source = source.replace('SetCircleLocalFrame.Invoke(__instance, new object[] { gameEntity.GetGlobalFrame() });', 'AssignCircleLocalFrame(__instance, gameEntity.GetGlobalFrame());')
+source = source.replace('SetCircleLocalFrame.Invoke(__instance, new object[] { MatrixFrame.Identity });', 'AssignCircleLocalFrame(__instance, MatrixFrame.Identity);')
+source = source.replace('SetCircleLocalFrame.Invoke(__instance, new object[] { circleLocalFrame });', 'AssignCircleLocalFrame(__instance, circleLocalFrame);')
+
+replace_once(
+'''                if (!MapScreen.VisualsOfEntities.ContainsKey(__instance.StrategicEntity.Pointer))
+                {
+                    MapScreen.VisualsOfEntities.Add(__instance.StrategicEntity.Pointer, __instance);
+                }
+                foreach (GameEntity gameEntity2 in gameEntities2)
+                {
+                    if (MapScreen.VisualsOfEntities.ContainsKey(gameEntity2.Pointer) || MapScreenPatch.FrameAndVisualOfEngines().ContainsKey(gameEntity2.Pointer))
+                    {
+                        continue;
+                    }
+                    MapScreen.VisualsOfEntities.Add(gameEntity2.Pointer, __instance);
+                }
+''',
+'''                var visualsOfEntities = MapScreen.VisualsOfEntities;
+                var engineVisuals = MapScreenPatch.FrameAndVisualOfEngines();
+                if (visualsOfEntities != null && !visualsOfEntities.ContainsKey(__instance.StrategicEntity.Pointer))
+                {
+                    visualsOfEntities.Add(__instance.StrategicEntity.Pointer, __instance);
+                }
+                foreach (GameEntity gameEntity2 in gameEntities2)
+                {
+                    if (gameEntity2 == null || visualsOfEntities == null ||
+                        visualsOfEntities.ContainsKey(gameEntity2.Pointer) ||
+                        (engineVisuals != null && engineVisuals.ContainsKey(gameEntity2.Pointer)))
+                    {
+                        continue;
+                    }
+                    visualsOfEntities.Add(gameEntity2.Pointer, __instance);
+                }
+''',
+'map visual dictionary guards')
+
+replace_once(
+'''            catch (System.Exception e) { LogManager.Log.NotifyBad(e); }
+
+            return true;
+        }
+''',
+'''            catch (System.Exception e)
+            {
+                if (handlingCustomVisual)
+                {
+                    LogManager.Log.SilentException(e);
+                    return false;
+                }
+
+                LogManager.Log.NotifyBad(e);
+                return true;
+            }
+        }
+''',
+'custom startup fail closed')
+
+path.write_text(source, encoding='utf-8')

--- a/_ps_visual_startup_fix_769/input/patch_visual_startup.py
+++ b/_ps_visual_startup_fix_769/input/patch_visual_startup.py
@@ -6,8 +6,9 @@ source = path.read_text(encoding='utf-8-sig')
 
 def replace_once(old: str, new: str, label: str):
     global source
-    if old not in source:
-        raise RuntimeError(f'marker not found: {label}')
+    count = source.count(old)
+    if count != 1:
+        raise RuntimeError(f'{label}: expected 1 marker, found {count}')
     source = source.replace(old, new, 1)
 
 replace_once(
@@ -44,17 +45,12 @@ replace_once(
 ''',
 '''        public static Scene MapScene(this SettlementVisual __instance)
         {
-            if (__instance == null)
+            if (__instance == null || GetMapScene == null)
             {
                 return null;
             }
 
-            if (GetMapScene != null)
-            {
-                return GetMapScene.Invoke(__instance, null) as Scene;
-            }
-
-            return (Campaign.Current?.MapSceneWrapper as MapScene)?.Scene;
+            return GetMapScene.Invoke(__instance, null) as Scene;
         }
 
         private static void AssignStrategicEntity(SettlementVisual visual, GameEntity entity)
@@ -67,10 +63,11 @@ replace_once(
             if (SetStrategicEntity != null)
             {
                 SetStrategicEntity.Invoke(visual, new object[] { entity });
-                return;
             }
-
-            StrategicEntityField?.SetValue(visual, entity);
+            else
+            {
+                StrategicEntityField?.SetValue(visual, entity);
+            }
         }
 
         private static void AssignTownPhysicalEntities(SettlementVisual visual, List<GameEntity> entities)
@@ -78,10 +75,11 @@ replace_once(
             if (SetTownPhysicalEntities != null)
             {
                 SetTownPhysicalEntities.Invoke(visual, new object[] { entities });
-                return;
             }
-
-            TownPhysicalEntitiesField?.SetValue(visual, entities);
+            else
+            {
+                TownPhysicalEntitiesField?.SetValue(visual, entities);
+            }
         }
 
         private static void AssignCircleLocalFrame(SettlementVisual visual, MatrixFrame frame)
@@ -89,24 +87,22 @@ replace_once(
             if (SetCircleLocalFrame != null)
             {
                 SetCircleLocalFrame.Invoke(visual, new object[] { frame });
-                return;
             }
-
-            CircleLocalFrameField?.SetValue(visual, frame);
+            else
+            {
+                CircleLocalFrameField?.SetValue(visual, frame);
+            }
         }
 ''',
 'accessor helpers')
 
-replace_once(
-'''        public static bool OnStartup(ref SettlementVisual __instance, ref Dictionary<int, List<GameEntity>> ____gateBannerEntitiesWithLevels)
-        {
-            try
-            {
-                OverwriteSettlementItem? overwriteItem = null;
-                bool isPlayerSettlement = (__instance.MapEntity != null && __instance.MapEntity.Settlement.IsPlayerBuilt());
-                bool isOverwrite = (__instance.MapEntity != null && __instance.MapEntity.Settlement.IsOverwritten(out overwriteItem));
-''',
-'''        public static bool OnStartup(ref SettlementVisual __instance, ref Dictionary<int, List<GameEntity>> ____gateBannerEntitiesWithLevels)
+start_marker = '''        [HarmonyPrefix]\n        [HarmonyPatch(nameof(OnStartup))]\n'''
+end_marker = '''\n\n        [HarmonyFinalizer]\n        //[HarmonyPatch(nameof(SettlementVisual.OnStartup))]'''
+start = source.index(start_marker)
+end = source.index(end_marker, start)
+new_method = '''        [HarmonyPrefix]
+        [HarmonyPatch(nameof(OnStartup))]
+        public static bool OnStartup(ref SettlementVisual __instance, ref Dictionary<int, List<GameEntity>> ____gateBannerEntitiesWithLevels)
         {
             bool handlingCustomVisual = false;
             try
@@ -122,36 +118,29 @@ replace_once(
                 OverwriteSettlementItem? overwriteItem = null;
                 bool isPlayerSettlement = settlement.IsPlayerBuilt();
                 bool isOverwrite = settlement.IsOverwritten(out overwriteItem);
-                handlingCustomVisual = isPlayerSettlement || isOverwrite;
-''',
-'custom visual preconditions')
+                if (!isPlayerSettlement && !isOverwrite)
+                {
+                    return true;
+                }
+                handlingCustomVisual = true;
 
-replace_once(
-'''                    SetStrategicEntity.Invoke(__instance, new object[] { __instance.MapScene().GetCampaignEntityWithName(__instance.MapEntity.Id) });
-''',
-'''                    var scene = __instance.MapScene();
-                    AssignStrategicEntity(__instance,
+                bool hasCircle = false;
+                if (!isOverwrite)
+                {
+                    Scene scene = __instance.MapScene();
+                    AssignStrategicEntity(
+                        __instance,
                         scene?.GetCampaignEntityWithName(mapEntity.Id)
                         ?? scene?.GetCampaignEntityWithName(settlement.StringId));
-''',
-'initial strategic entity assignment')
-
-replace_once(
-'''                    IMapScene mapSceneWrapper = Campaign.Current.MapSceneWrapper;
-                    string stringId = (__instance as MapEntityVisual<PartyBase>).MapEntity.Settlement.StringId;
-                    CampaignVec2 position = (__instance as MapEntityVisual<PartyBase>).MapEntity.Settlement.Position;
-                    mapSceneWrapper.AddNewEntityToMapScene(stringId, in position);
-                    SetStrategicEntity.Invoke(__instance, new object[] { __instance.MapScene().GetCampaignEntityWithName((__instance as MapEntityVisual<PartyBase>).MapEntity.Id) });
                 }
-''',
-'''                    IMapScene mapSceneWrapper = Campaign.Current?.MapSceneWrapper;
+
+                if (__instance.StrategicEntity == null)
+                {
+                    IMapScene mapSceneWrapper = Campaign.Current?.MapSceneWrapper;
+                    Scene scene = __instance.MapScene();
                     string stringId = settlement.StringId;
                     CampaignVec2 position = settlement.Position;
-                    var scene = __instance.MapScene();
 
-                    // ToR template ids are not native campaign-map prefab ids. Recreate their
-                    // visual from an independent same-culture prefab before asking the native
-                    // map-scene wrapper to resolve the generated settlement id.
                     GameEntity copiedVisual = CultureVisualHelper.TryCopyCreatedSettlementVisual(
                         scene,
                         stringId,
@@ -163,7 +152,8 @@ replace_once(
                     else
                     {
                         mapSceneWrapper?.AddNewEntityToMapScene(stringId, in position);
-                        AssignStrategicEntity(__instance,
+                        AssignStrategicEntity(
+                            __instance,
                             scene?.GetCampaignEntityWithName(mapEntity.Id)
                             ?? scene?.GetCampaignEntityWithName(stringId));
                     }
@@ -174,106 +164,159 @@ replace_once(
                     LogManager.Log.Info($"Player settlement visual startup skipped because no strategic entity could be resolved for '{settlement.StringId}'.");
                     return false;
                 }
-''',
-'strategic entity fallback')
 
-source = source.replace('(__instance as MapEntityVisual<PartyBase>).MapEntity.Settlement', 'settlement')
-source = source.replace('(__instance as MapEntityVisual<PartyBase>).MapEntity.IsSettlement', 'mapEntity.IsSettlement')
-source = source.replace('(__instance as MapEntityVisual<PartyBase>).MapEntity.IsVisible', 'mapEntity.IsVisible')
-source = source.replace('__instance.MapEntity.Settlement', 'settlement')
+                if (overwriteItem == null)
+                {
+                    var playerSettlementItem = PlayerSettlementInfo.Instance?.FindSettlement(settlement);
+                    ApplySavedVisualTransform(__instance.StrategicEntity, playerSettlementItem?.RotationMat3, playerSettlementItem?.DeepEdits);
+                }
+                else
+                {
+                    ApplySavedVisualTransform(__instance.StrategicEntity, overwriteItem.RotationMat3, overwriteItem.DeepEdits);
+                }
 
-replace_once(
-'''                    PopulateSiegeEngineFrameListsFromChildren.Invoke(__instance, new object[] { gameEntities });
-                    UpdateDefenderSiegeEntitiesCache.Invoke(__instance, null);
-                    SetTownPhysicalEntities.Invoke(__instance, new object[] { gameEntities.FindAll((GameEntity x) => x.HasTag("bo_town")) });
-''',
-'''                    PopulateSiegeEngineFrameListsFromChildren?.Invoke(__instance, new object[] { gameEntities });
+                if (settlement.IsFortification)
+                {
+                    List<GameEntity> gameEntities = new List<GameEntity>();
+                    __instance.StrategicEntity.GetChildrenRecursive(ref gameEntities);
+                    gameEntities.RemoveAll(entity => entity == null);
+
+                    PopulateSiegeEngineFrameListsFromChildren?.Invoke(__instance, new object[] { gameEntities });
                     UpdateDefenderSiegeEntitiesCache?.Invoke(__instance, null);
-                    AssignTownPhysicalEntities(__instance, gameEntities.FindAll((GameEntity x) => x != null && x.HasTag("bo_town")));
-''',
-'fortification reflection guards')
+                    AssignTownPhysicalEntities(__instance, gameEntities.FindAll(entity => entity.HasTag("bo_town")));
 
-replace_once(
-'''                        int upgradeLevelOfEntity = gameEntity.Parent.GetUpgradeLevelOfEntity();
-                        if (upgradeLevelOfEntity != 0)
+                    List<GameEntity> mapInteractionEntities = new List<GameEntity>();
+                    Dictionary<int, List<GameEntity>> bannerEntitiesByLevel = new Dictionary<int, List<GameEntity>>()
+                    {
+                        { 1, new List<GameEntity>() },
+                        { 2, new List<GameEntity>() },
+                        { 3, new List<GameEntity>() }
+                    };
+
+                    foreach (GameEntity gameEntity in gameEntities)
+                    {
+                        if (gameEntity.HasTag("main_map_city_gate"))
                         {
-                            nums[upgradeLevelOfEntity].Add(gameEntity);
+                            MatrixFrame globalFrame = gameEntity.GetGlobalFrame();
+                            NavigationHelper.IsPositionValidForNavigationType(
+                                new CampaignVec2(globalFrame.origin.AsVec2, true),
+                                MobileParty.NavigationType.Default);
+                            mapInteractionEntities.Add(gameEntity);
                         }
-''',
-'''                        int upgradeLevelOfEntity = gameEntity.Parent?.GetUpgradeLevelOfEntity() ?? 0;
-                        if (upgradeLevelOfEntity != 0 && nums.TryGetValue(upgradeLevelOfEntity, out var levelEntities))
+
+                        if (gameEntity.HasTag("map_settlement_circle"))
+                        {
+                            AssignCircleLocalFrame(__instance, gameEntity.GetGlobalFrame());
+                            hasCircle = true;
+                            gameEntity.SetVisibilityExcludeParents(false);
+                            mapInteractionEntities.Add(gameEntity);
+                        }
+
+                        if (!gameEntity.HasTag("map_banner_placeholder"))
+                        {
+                            continue;
+                        }
+
+                        int upgradeLevel = gameEntity.Parent?.GetUpgradeLevelOfEntity() ?? 0;
+                        if (upgradeLevel != 0 && bannerEntitiesByLevel.TryGetValue(upgradeLevel, out List<GameEntity> levelEntities))
                         {
                             levelEntities.Add(gameEntity);
                         }
-''',
-'banner parent and level guard')
-
-replace_once(
-'''                        Campaign.Current.MapSceneWrapper.GetSiegeCampFrames(settlement, out matricesFrame, out matricesFrame1);
-                        settlement.Town.BesiegerCampPositions1 = matricesFrame.ToArray();
-                        settlement.Town.BesiegerCampPositions2 = matricesFrame1.ToArray();
-''',
-'''                        if (Campaign.Current?.MapSceneWrapper != null)
-                        {
-                            Campaign.Current.MapSceneWrapper.GetSiegeCampFrames(settlement, out matricesFrame, out matricesFrame1);
-                        }
                         else
                         {
-                            matricesFrame = new List<MatrixFrame>();
-                            matricesFrame1 = new List<MatrixFrame>();
+                            bannerEntitiesByLevel[1].Add(gameEntity);
+                            bannerEntitiesByLevel[2].Add(gameEntity);
+                            bannerEntitiesByLevel[3].Add(gameEntity);
                         }
-                        if (settlement.Town != null)
-                        {
-                            settlement.Town.BesiegerCampPositions1 = (matricesFrame ?? new List<MatrixFrame>()).ToArray();
-                            settlement.Town.BesiegerCampPositions2 = (matricesFrame1 ?? new List<MatrixFrame>()).ToArray();
-                        }
-''',
-'siege camp frame null guards')
-
-source = source.replace('SetCircleLocalFrame.Invoke(__instance, new object[] { gameEntity.GetGlobalFrame() });', 'AssignCircleLocalFrame(__instance, gameEntity.GetGlobalFrame());')
-source = source.replace('SetCircleLocalFrame.Invoke(__instance, new object[] { MatrixFrame.Identity });', 'AssignCircleLocalFrame(__instance, MatrixFrame.Identity);')
-source = source.replace('SetCircleLocalFrame.Invoke(__instance, new object[] { circleLocalFrame });', 'AssignCircleLocalFrame(__instance, circleLocalFrame);')
-
-replace_once(
-'''                if (!MapScreen.VisualsOfEntities.ContainsKey(__instance.StrategicEntity.Pointer))
-                {
-                    MapScreen.VisualsOfEntities.Add(__instance.StrategicEntity.Pointer, __instance);
-                }
-                foreach (GameEntity gameEntity2 in gameEntities2)
-                {
-                    if (MapScreen.VisualsOfEntities.ContainsKey(gameEntity2.Pointer) || MapScreenPatch.FrameAndVisualOfEngines().ContainsKey(gameEntity2.Pointer))
-                    {
-                        continue;
+                        mapInteractionEntities.Add(gameEntity);
                     }
-                    MapScreen.VisualsOfEntities.Add(gameEntity2.Pointer, __instance);
+                    ____gateBannerEntitiesWithLevels = bannerEntitiesByLevel;
+
+                    List<MatrixFrame> campFrames1 = new List<MatrixFrame>();
+                    List<MatrixFrame> campFrames2 = new List<MatrixFrame>();
+                    if (Campaign.Current?.MapSceneWrapper != null)
+                    {
+                        Campaign.Current.MapSceneWrapper.GetSiegeCampFrames(settlement, out campFrames1, out campFrames2);
+                    }
+                    if (settlement.Town != null)
+                    {
+                        settlement.Town.BesiegerCampPositions1 = (campFrames1 ?? new List<MatrixFrame>()).ToArray();
+                        settlement.Town.BesiegerCampPositions2 = (campFrames2 ?? new List<MatrixFrame>()).ToArray();
+                    }
+
+                    foreach (GameEntity interactionEntity in mapInteractionEntities)
+                    {
+                        interactionEntity.Remove(112);
+                    }
+
+                    if (mapEntity.IsSettlement)
+                    {
+                        foreach (GameEntity child in __instance.StrategicEntity.GetChildren())
+                        {
+                            if (!child.HasTag("main_map_city_port"))
+                            {
+                                continue;
+                            }
+                            MatrixFrame portFrame = child.GetGlobalFrame();
+                            NavigationHelper.IsPositionValidForNavigationType(
+                                new CampaignVec2(portFrame.origin.AsVec2, false),
+                                MobileParty.NavigationType.Naval);
+                        }
+                    }
                 }
-''',
-'''                var visualsOfEntities = MapScreen.VisualsOfEntities;
+
+                if (!hasCircle)
+                {
+                    AssignCircleLocalFrame(__instance, MatrixFrame.Identity);
+                    MatrixFrame circleLocalFrame = __instance.CircleLocalFrame;
+                    Mat3 circleRotation = circleLocalFrame.rotation;
+                    if (settlement.IsVillage)
+                    {
+                        circleRotation.ApplyScaleLocal(1.75f);
+                    }
+                    else if (settlement.IsTown)
+                    {
+                        circleRotation.ApplyScaleLocal(5.75f);
+                    }
+                    else if (settlement.IsCastle)
+                    {
+                        circleRotation.ApplyScaleLocal(2.75f);
+                    }
+                    else
+                    {
+                        circleRotation.ApplyScaleLocal(1.75f);
+                    }
+                    circleLocalFrame.rotation = circleRotation;
+                    AssignCircleLocalFrame(__instance, circleLocalFrame);
+                }
+
+                __instance.StrategicEntity.SetVisibilityExcludeParents(mapEntity.IsVisible);
+                __instance.StrategicEntity.SetReadyToRender(true);
+                __instance.StrategicEntity.SetEntityEnvMapVisibility(false);
+
+                List<GameEntity> childEntities = new List<GameEntity>();
+                __instance.StrategicEntity.GetChildrenRecursive(ref childEntities);
+                var visualsOfEntities = MapScreen.VisualsOfEntities;
                 var engineVisuals = MapScreenPatch.FrameAndVisualOfEngines();
                 if (visualsOfEntities != null && !visualsOfEntities.ContainsKey(__instance.StrategicEntity.Pointer))
                 {
                     visualsOfEntities.Add(__instance.StrategicEntity.Pointer, __instance);
                 }
-                foreach (GameEntity gameEntity2 in gameEntities2)
+                foreach (GameEntity childEntity in childEntities)
                 {
-                    if (gameEntity2 == null || visualsOfEntities == null ||
-                        visualsOfEntities.ContainsKey(gameEntity2.Pointer) ||
-                        (engineVisuals != null && engineVisuals.ContainsKey(gameEntity2.Pointer)))
+                    if (childEntity == null || visualsOfEntities == null ||
+                        visualsOfEntities.ContainsKey(childEntity.Pointer) ||
+                        (engineVisuals != null && engineVisuals.ContainsKey(childEntity.Pointer)))
                     {
                         continue;
                     }
-                    visualsOfEntities.Add(gameEntity2.Pointer, __instance);
+                    visualsOfEntities.Add(childEntity.Pointer, __instance);
                 }
-''',
-'map visual dictionary guards')
 
-replace_once(
-'''            catch (System.Exception e) { LogManager.Log.NotifyBad(e); }
-
-            return true;
-        }
-''',
-'''            catch (System.Exception e)
+                __instance.StrategicEntity.SetAsPredisplayEntity();
+                return false;
+            }
+            catch (System.Exception e)
             {
                 if (handlingCustomVisual)
                 {
@@ -285,7 +328,62 @@ replace_once(
                 return true;
             }
         }
-''',
-'custom startup fail closed')
 
-path.write_text(source, encoding='utf-8')
+        private static void ApplySavedVisualTransform(GameEntity strategicEntity, Mat3Saveable? rotation, List<DeepTransformEdit> deepEdits)
+        {
+            if (strategicEntity == null)
+            {
+                return;
+            }
+
+            if (rotation != null)
+            {
+                MatrixFrame frame = strategicEntity.GetFrame();
+                frame.rotation = rotation;
+                strategicEntity.SetFrame(ref frame);
+            }
+
+            if (deepEdits == null)
+            {
+                return;
+            }
+
+            List<GameEntity> children = new List<GameEntity>();
+            strategicEntity.GetChildrenRecursive(ref children);
+            foreach (DeepTransformEdit edit in deepEdits)
+            {
+                if (edit == null || edit.Index >= children.Count)
+                {
+                    continue;
+                }
+
+                GameEntity entity = edit.Index < 0 ? strategicEntity : children[edit.Index];
+                if (entity == null)
+                {
+                    continue;
+                }
+
+                MatrixFrame local = entity.GetFrame();
+                local.rotation = edit.Transform?.RotationScale != null ? edit.Transform.RotationScale : local.rotation;
+                if (edit.Index >= 0)
+                {
+                    local.origin = edit.Transform?.Position != null ? edit.Transform.Position : local.origin;
+                }
+                else if (edit.Transform?.Offsets != null)
+                {
+                    local.origin += edit.Transform.Offsets;
+                }
+                entity.SetFrame(ref local);
+            }
+
+            foreach (DeepTransformEdit edit in deepEdits.AsEnumerable().Reverse().Where(item => item != null && item.IsDeleted && item.Index >= 0))
+            {
+                if (edit.Index < children.Count)
+                {
+                    children[edit.Index]?.ClearEntity();
+                }
+            }
+        }
+'''
+source = source[:start] + new_method + source[end:]
+path.write_text(source, encoding='utf-8', newline='\n')

--- a/_ps_visual_startup_fix_769/input/patch_visual_startup.py
+++ b/_ps_visual_startup_fix_769/input/patch_visual_startup.py
@@ -147,11 +147,26 @@ replace_once(
 '''                    IMapScene mapSceneWrapper = Campaign.Current?.MapSceneWrapper;
                     string stringId = settlement.StringId;
                     CampaignVec2 position = settlement.Position;
-                    mapSceneWrapper?.AddNewEntityToMapScene(stringId, in position);
                     var scene = __instance.MapScene();
-                    AssignStrategicEntity(__instance,
-                        scene?.GetCampaignEntityWithName(mapEntity.Id)
-                        ?? scene?.GetCampaignEntityWithName(stringId));
+
+                    // ToR template ids are not native campaign-map prefab ids. Recreate their
+                    // visual from an independent same-culture prefab before asking the native
+                    // map-scene wrapper to resolve the generated settlement id.
+                    GameEntity copiedVisual = CultureVisualHelper.TryCopyCreatedSettlementVisual(
+                        scene,
+                        stringId,
+                        settlement.Position.ToVec2());
+                    if (copiedVisual != null)
+                    {
+                        AssignStrategicEntity(__instance, copiedVisual);
+                    }
+                    else
+                    {
+                        mapSceneWrapper?.AddNewEntityToMapScene(stringId, in position);
+                        AssignStrategicEntity(__instance,
+                            scene?.GetCampaignEntityWithName(mapEntity.Id)
+                            ?? scene?.GetCampaignEntityWithName(stringId));
+                    }
                 }
 
                 if (__instance.StrategicEntity == null)
@@ -198,7 +213,15 @@ replace_once(
                         settlement.Town.BesiegerCampPositions1 = matricesFrame.ToArray();
                         settlement.Town.BesiegerCampPositions2 = matricesFrame1.ToArray();
 ''',
-'''                        Campaign.Current?.MapSceneWrapper?.GetSiegeCampFrames(settlement, out matricesFrame, out matricesFrame1);
+'''                        if (Campaign.Current?.MapSceneWrapper != null)
+                        {
+                            Campaign.Current.MapSceneWrapper.GetSiegeCampFrames(settlement, out matricesFrame, out matricesFrame1);
+                        }
+                        else
+                        {
+                            matricesFrame = new List<MatrixFrame>();
+                            matricesFrame1 = new List<MatrixFrame>();
+                        }
                         if (settlement.Town != null)
                         {
                             settlement.Town.BesiegerCampPositions1 = (matricesFrame ?? new List<MatrixFrame>()).ToArray();


### PR DESCRIPTION
Temporary CI-only build. The 7.6.8.2 runtime diagnostics identified the repeated startup NullReferenceExceptions in PlayerSettlement's SettlementVisual.OnStartup prefix. Reconstructed and compiled PlayerSettlement 7.6.9 with null-safe custom visual startup, integrated same-culture ToR visual copying, exact-culture preview preservation, and the existing raid/siege ownership fixes. Build workflow and repository safety invariant passed. Artifact retrieved, packaged, and validated. Closed without merge.